### PR TITLE
add process_id to logging to be better conformed for log parsers

### DIFF
--- a/bin/argolog.py
+++ b/bin/argolog.py
@@ -28,7 +28,7 @@ def init_log(log_mode, log_file, log_level, log_name):
 
         file_log = logging.FileHandler(log_file)
         file_format = logging.Formatter(
-            '%(asctime)s [%(name)s] %(levelname)s %(message)s')
+            '%(asctime)s %(name)s[%(process)d]: %(levelname)s %(message)s')
         file_log.setFormatter(file_format)
 
         log.addHandler(file_log)
@@ -37,7 +37,7 @@ def init_log(log_mode, log_file, log_level, log_name):
     elif log_mode == 'syslog':
 
         sys_log = logging.handlers.SysLogHandler("/dev/log")
-        sys_format = logging.Formatter('[%(name)s] %(levelname)s %(message)s')
+        sys_format = logging.Formatter('%(name)s[%(process)d]: %(levelname)s %(message)s')
         sys_log.setFormatter(sys_format)
 
         log.addHandler(sys_log)

--- a/bin/argorun.py
+++ b/bin/argorun.py
@@ -13,8 +13,8 @@ def run_cmd(cmd_args, log):
     try:
         check_call(cmd_args)
     except CalledProcessError:
-        log.error("Error while executing [%s]", exec_name)
+        log.error("Error while executing %s", exec_name)
         exit(1)
     except OSError:
-        log.error("Could not locate [%s] at path: %s", exec_name, exec_path)
+        log.error("Could not locate %s at path: %s", exec_name, exec_path)
         exit(1)


### PR DESCRIPTION
The logging format has been slightly changed and process id has been added to be better conformed with the format expected by log parsers (logstash,splunk etc)

before:
timestamp  [process_name] level message
after:
timestamp  process_name[proc_id]:  level  message  

The change was implemented to the python logging formaters (both for the two handlers: file / syslog)