### PR TITLE
ARGO-45 Configuration of pig and hadoop clients logging from within CE

### DIFF
--- a/bin/job_cycle.py
+++ b/bin/job_cycle.py
@@ -26,6 +26,10 @@ def main(args=None):
     if log_mode == 'file':
         log_file = ArConfig.get('logging', 'log_file')
 
+    if log_mode == 'syslog':
+        # Set hadoop logger settings
+        os.environ["HADOOP_ROOT_LOGGER"] = ArConfig.get('logging', 'hadoop_log_opts')
+
     log_level = ArConfig.get('logging', 'log_level')
     log = init_log(log_mode, log_file, log_level, 'argo.job_cycle')
 

--- a/bin/job_cycle.py
+++ b/bin/job_cycle.py
@@ -19,11 +19,6 @@ def main(args=None):
     ArConfig = SafeConfigParser()
     ArConfig.read(fn_ar_cfg)
 
-    # Set hadoop and pig clients logging settings
-    os.environ["HADOOP_LOG_DIR"] = "/tmp"
-    os.environ["HADOOP_LOGFILE"] = "hadoop.log"
-    os.environ["HADOOP_ROOT_LOGGER"] = "INFO,console,RFA"
-
     # Initialize logging
     log_mode = ArConfig.get('logging', 'log_mode')
     log_file = 'none'

--- a/bin/job_cycle.py
+++ b/bin/job_cycle.py
@@ -26,9 +26,8 @@ def main(args=None):
     if log_mode == 'file':
         log_file = ArConfig.get('logging', 'log_file')
 
-    if log_mode == 'syslog':
-        # Set hadoop logger settings
-        os.environ["HADOOP_ROOT_LOGGER"] = ArConfig.get('logging', 'hadoop_log_opts')
+    # Set hadoop root logger settings
+    os.environ["HADOOP_ROOT_LOGGER"] = ArConfig.get('logging', 'hadoop_log_root')
 
     log_level = ArConfig.get('logging', 'log_level')
     log = init_log(log_mode, log_file, log_level, 'argo.job_cycle')

--- a/bin/job_cycle.py
+++ b/bin/job_cycle.py
@@ -19,6 +19,13 @@ def main(args=None):
     ArConfig = SafeConfigParser()
     ArConfig.read(fn_ar_cfg)
 
+    # Set hadoop and pig clients logging settings
+    os.environ["HADOOP_LOG_DIR"] = "/tmp"
+    os.environ["HADOOP_LOGFILE"] = "hadoop.log"
+    os.environ["HADOOP_ROOT_LOGGER"] = "INFO,console,RFA"
+    os.environ["PIG_LOG_DIR"] = "/tmp"
+    os.environ["PIG_LOGFILE"] = "pig.log"
+
     # Initialize logging
     log_mode = ArConfig.get('logging', 'log_mode')
     log_file = 'none'

--- a/bin/job_cycle.py
+++ b/bin/job_cycle.py
@@ -23,8 +23,6 @@ def main(args=None):
     os.environ["HADOOP_LOG_DIR"] = "/tmp"
     os.environ["HADOOP_LOGFILE"] = "hadoop.log"
     os.environ["HADOOP_ROOT_LOGGER"] = "INFO,console,RFA"
-    os.environ["PIG_LOG_DIR"] = "/tmp"
-    os.environ["PIG_LOGFILE"] = "pig.log"
 
     # Initialize logging
     log_mode = ArConfig.get('logging', 'log_mode')

--- a/conf/ar-compute-engine.conf
+++ b/conf/ar-compute-engine.conf
@@ -30,8 +30,15 @@ log_level=DEBUG
 # If log_mode equals file - uncomment to set log file path:
 # log_file=/var/log/ar-compute/ar-compute.log
 
-# Hadoop client log configuration
-hadoop_log_opts=INFO,SYSLOG
+# Hadoop clients log level and log appender
+# If you want to log via SYSLOG make sure
+# an appropriate appender is defined in hadoop
+# log4j.properties file and just add the name
+# of this appender in the following line. I.e. 
+# if you define a new appender named SYSLOG 
+# change console to SYSLOG, or just add 
+# SYSLOG appender in the following line
+hadoop_log_root=INFO,console
 
 [jobs]
 

--- a/conf/ar-compute-engine.conf
+++ b/conf/ar-compute-engine.conf
@@ -30,6 +30,8 @@ log_level=DEBUG
 # If log_mode equals file - uncomment to set log file path:
 # log_file=/var/log/ar-compute/ar-compute.log
 
+# Hadoop client log configuration
+hadoop_log_opts=INFO,SYSLOG
 
 [jobs]
 


### PR DESCRIPTION
Setting of five environment variables from within job_cycle.py script, so that tools the CE uses log properly to some log files what is going one per computation.  