### PR TITLE
Better tenant/job declaration in conf file (multitenant enviroments)

### DIFF
--- a/bin/job_cycle.py
+++ b/bin/job_cycle.py
@@ -27,47 +27,57 @@ def main(args=None):
         log_file = ArConfig.get('logging', 'log_file')
 
     # Set hadoop root logger settings
-    os.environ["HADOOP_ROOT_LOGGER"] = ArConfig.get('logging', 'hadoop_log_root')
+    os.environ["HADOOP_ROOT_LOGGER"] = ArConfig.get(
+        'logging', 'hadoop_log_root')
 
     log_level = ArConfig.get('logging', 'log_level')
     log = init_log(log_mode, log_file, log_level, 'argo.job_cycle')
 
-    tenant = ArConfig.get("jobs", "tenant")
-    job_set = ArConfig.get("jobs", "job_set")
-    job_set = job_set.split(',')
+    # Get the available tenants from config file
+    tenant_list = ArConfig.get("jobs", "tenants")
+    tenant_list = tenant_list.split(',')
 
-    # Notify that he job cycle has begun
-    log.info(
-        "Job Cycle: started for tenant:%s and date: %s", tenant, args.date)
+    # For each available tenant prepare and execute all tenant's jobs
+    for tenant in tenant_list:
 
-    # Command to upload the prefilter data
-    cmd_upload_metric = [
-        os.path.join(sdl_exec, "upload_metric.py"), '-d', args.date, '-t', tenant]
+        # Get specific tenant's job set
+        job_set = ArConfig.get("jobs", tenant + '_jobs')
+        job_set = job_set.split(',')
 
-    log.info("Job Cycle: Upload metric data to hdfs")
-    run_cmd(cmd_upload_metric, log)
+        # Notify that he job cycle has begun
+        log.info(
+            "Job Cycle: started for tenant:%s and date: %s", tenant, args.date)
 
-    # Command to submit job status detail
-    cmd_job_status = [
-        os.path.join(sdl_exec, "job_status_detail.py"), '-d', args.date, '-t', tenant]
+        # Command to upload the prefilter data
+        cmd_upload_metric = [
+            os.path.join(sdl_exec, "upload_metric.py"), '-d', args.date, '-t', tenant]
 
-    log.info(
-        "Job Cycle: Run status detail job for tenant:%s and date: %s", tenant, args.date)
-    run_cmd(cmd_job_status, log)
+        log.info("Job Cycle: Upload metric data to hdfs")
+        run_cmd(cmd_upload_metric, log)
 
-    log.info("Job Cycle: Iterate over a/r jobs and submit them")
-    # For each job genereate ar
-    for item in job_set:
-        log.info("Job Cycle: tenant %s has job named %s", tenant, item)
-        cmd_job_ar = [
-            os.path.join(sdl_exec, "job_ar.py"), '-d', args.date, '-t', tenant, '-j', item]
-        run_cmd(cmd_job_ar, log)
+        # Command to submit job status detail
+        cmd_job_status = [
+            os.path.join(sdl_exec, "job_status_detail.py"), '-d', args.date, '-t', tenant]
+
+        log.info(
+            "Job Cycle: Run status detail job for tenant:%s and date: %s", tenant, args.date)
+        run_cmd(cmd_job_status, log)
+
+        log.info("Job Cycle: Iterate over a/r jobs and submit them")
+
+        # For each job genereate ar
+        for job in job_set:
+            log.info("Job Cycle: tenant %s has job named %s", tenant, job)
+            cmd_job_ar = [
+                os.path.join(sdl_exec, "job_ar.py"), '-d', args.date, '-t', tenant, '-j', job]
+            run_cmd(cmd_job_ar, log)
 
 if __name__ == "__main__":
 
     # Feed Argument parser with the description of the 3 arguments we need
     # (input_file,output_file,schema_file)
-    arg_parser = ArgumentParser(description="Cycling daily jobs for a tenant")
+    arg_parser = ArgumentParser(
+        description="Cycling daily jobs for all available tenants")
     arg_parser.add_argument(
         "-d", "--date", help="date", dest="date", metavar="DATE", required="TRUE")
     # Parse the command line arguments accordingly and introduce them to

--- a/bin/job_status_detail.py
+++ b/bin/job_status_detail.py
@@ -45,7 +45,7 @@ def main(args=None):
     mongo_port = ArConfig.get('default', 'mongo_port')
     mongo_dest = ArConfig.get('datastore_mapping', 'sdetail_dest')
     ar_mode = ArConfig.get('default', 'mode')
-    job_set = ArConfig.get("jobs", "job_set")
+    job_set = ArConfig.get("jobs", args.tenant + "_jobs")
     job_set = job_set.split(',')
 
     # check if sync_data must be cleaned in hdfs

--- a/bin/sync_backup.py
+++ b/bin/sync_backup.py
@@ -55,7 +55,7 @@ def main(args=None):
     sync_tar = tarfile.open(local_tar, mode='w')
 
     # Grab all available jobs in the system
-    job_set = ArConfig.get("jobs", "job_set")
+    job_set = ArConfig.get("jobs", args.tenant+"_jobs")
     job_set = job_set.split(',')
 
     # Create query strings to list appropriate files

--- a/conf/ar-compute-engine.conf
+++ b/conf/ar-compute-engine.conf
@@ -42,9 +42,21 @@ hadoop_log_root=INFO,console
 
 [jobs]
 
-tenant=EGI
-job_set=Critical,Cloudmon
+# Here are declared available tenants and available jobs
+# for each tenant (tenant/job names are case-sensitive)
+# The order of declarations is as follows:
+#
+# tenants=TenantA,TenantB
+# TenantA_jobs=Job1,Job2,Job3
+# TenantB_jobs=Job4,Job5
 
+# Declare available tenants
+tenants=EGI
+
+# For a declared tenant declare it's jobs by using 
+# {Tenant_Name}_jobs conformance
+
+EGI_jobs=Critical,Cloudmon
 
 
 


### PR DESCRIPTION
Derived from ARGO-67 Issue

Derived from work on documenting argo-engine configuration (https://github.com/ARGOeu/argodoc/pull/5):

In multi-tenant enviroments there is the need to configure a list of available tenants
and also for each tenant a list of jobs. 

Right now ar-compute engine conf there is the following section:
[jobs]
tenant=tenantA 
job_set=job1,job2 etc...

With this patch the .conf declaration changes to:
[jobs]
tenants=tenantA,tenantB
tenantA_jobs=job1,job2,job3
tenantB_jobs=job4,job5

which is needed in multi-tenant enviroments and gives a better understanding to the end-user on what is actually configured.

If accepted it will be reflected in the documentation also