### PR TITLE
[WIP] ARGO-73 Initial poller implementation.

### DIFF
--- a/bin/poller_ar.py
+++ b/bin/poller_ar.py
@@ -1,65 +1,101 @@
 #!/usr/bin/env python
 
 import sys
-from argolog import init_log
-from argparse import ArgumentParser
 from ConfigParser import SafeConfigParser
+
+from argparse import ArgumentParser
 from pymongo import MongoClient
 from bson.objectid import ObjectId
 
-def main(args=None):
+from argolog import init_log
 
-    # default config
-    fn_ar_cfg = "/etc/ar-compute-engine.conf"
 
+def get_poller_config(fn_ar_cfg="/etc/ar-compute-engine.conf", logging_config='logging', default_config='default'):
+    """
+    Initialize the logger and retrieve the settings for the poller
+    :param fn_ar_cfg: file from which to retrieve configuration
+    :param logging_config: logging section of the configuration
+    :param default_config: default section of the configuration
+    :return: logger instance, mongo hostname, mongo port and threshold of running recomputations in a tuple
+    """
+    # Read Configuration file
     ArConfig = SafeConfigParser()
     ArConfig.read(fn_ar_cfg)
 
-     # Initialize logging
-    log_mode = ArConfig.get('logging', 'log_mode')
-    log_file = 'none'
-
-    if log_mode == 'file':
-        log_file = ArConfig.get('logging', 'log_file')
-
-    log_level = ArConfig.get('logging', 'log_level')
+    # Initialize logging
+    log_mode = ArConfig.get(logging_config, 'log_mode')
+    log_file = ArConfig.get(logging_config, 'log_file') if log_mode == 'file' else None
+    log_level = ArConfig.get(logging_config, 'log_level')
     log = init_log(log_mode, log_file, log_level, 'argo.poller')
 
+    # Get mongo configurations
+    mongo_host = ArConfig.get(default_config, 'mongo_host')
+    mongo_port = ArConfig.get(default_config, 'mongo_port')
 
-    mongo_host = ArConfig.get('default', 'mongo_host')
-    mongo_port = ArConfig.get('default', 'mongo_port')
-
-    threshold = int(ArConfig.get('default', 'recomp_threshold'))
+    threshold = int(ArConfig.get(default_config, 'recomp_threshold'))
     log.info("Threshold: %s", threshold)
+    return log, mongo_host, mongo_port, threshold
 
+
+def get_mongo_collection(mongo_host, mongo_port):
+    """
+    :return: pymongo collection object of the recalculations collection
+    """
     client = MongoClient(mongo_host, int(mongo_port))
     db = client["AR"]
     col = db["recalculations"]
-    num_pen = col.find({ "s": "pending" }).count()
-    num_run = col.find({ "s": "running" }).count()
+    return col
+
+
+def get_pending_and_running(col):
+    """
+    :param col: pymongo collection object
+    :return: number of pending requests and running recalculation requests
+    """
+    num_pen = col.find({"s": "pending"}).count()
+    num_run = col.find({"s": "running"}).count()
+    return num_pen, num_run
+
+
+def run_recomputation(col):
+    """
+    Retrives the first pending recalculation in the db request and queues it for recalculation
+    :param col: pymongo collection object
+    """
+    #TODO: add the recomputation executor
+    raise NotImplementedError("recomputation executor not added")
+    pen_recalc = col.find_one({"s": "pending"})
+    pen_recalc_id = str(pen_recalc["_id"])
+    col.update({"_id": ObjectId(pen_recalc_id)}, {"$set": {"s": "running"}})
+
+
+def main(args=None):
+    """
+    Checks if there are any pending recomputation requests and if the running
+    requests do not exceed a threshold and queues another one to be recomputed
+    :param args:
+    :return:
+    """
+    log, mongo_host, mongo_port, threshold = get_poller_config()
+    col = get_mongo_collection(mongo_host=mongo_host, mongo_port=mongo_port)
+    num_pen, num_run = get_pending_and_running(col)
     log.info("Running recalculations: %s (threshold: %s)", num_run, threshold)
 
     if num_pen == 0:
         log.info("No pending recomputations present")
-
     elif num_run < threshold:
-    	log.info("Below threshold; recomputation is about to be executed...")
-    	pen_recalc = col.find_one({"s":"pending"})
-    	pen_recalc_id = str(pen_recalc["_id"])
-    	col.update({ "_id": ObjectId(pen_recalc_id) }, { "$set": { "s": "running" } })
-
-        # TODO: placeholder: call recomputation executor.
-
+        log.info("Below threshold; recomputation is about to be executed...")
+        run_recomputation(col)
     else:
-    	log.info("Over threshold; no recomputation will be executed.")
+        log.info("Over threshold; no recomputation will be executed.")
+
 
 if __name__ == "__main__":
-
     # Feed Argument parser with the description
     # No arguments needed
     arg_parser = ArgumentParser(
         description="Polling for pending recomputations requests")
-    
+
     # Parse the command line arguments accordingly and introduce them to
     # main...
     sys.exit(main(arg_parser.parse_args()))

--- a/bin/poller_ar.py
+++ b/bin/poller_ar.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+import sys
+from argolog import init_log
+from argparse import ArgumentParser
+from ConfigParser import SafeConfigParser
+from pymongo import MongoClient
+from bson.objectid import ObjectId
+
+def main(args=None):
+
+    # default config
+    fn_ar_cfg = "/etc/ar-compute-engine.conf"
+
+    ArConfig = SafeConfigParser()
+    ArConfig.read(fn_ar_cfg)
+
+     # Initialize logging
+    log_mode = ArConfig.get('logging', 'log_mode')
+    log_file = 'none'
+
+    if log_mode == 'file':
+        log_file = ArConfig.get('logging', 'log_file')
+
+    log_level = ArConfig.get('logging', 'log_level')
+    log = init_log(log_mode, log_file, log_level, 'argo.poller')
+
+
+    mongo_host = ArConfig.get('default', 'mongo_host')
+    mongo_port = ArConfig.get('default', 'mongo_port')
+
+    threshold = int(ArConfig.get('default', 'recomp_threshold'))
+    log.info("Threshold: %s", threshold)
+
+    client = MongoClient(mongo_host, int(mongo_port))
+    db = client["AR"]
+    col = db["recalculations"]
+    num_pen = col.find({ "s": "pending" }).count()
+    num_run = col.find({ "s": "running" }).count()
+    log.info("Running recalculations: %s (threshold: %s)", num_run, threshold)
+
+    if num_pen == 0:
+        log.info("No pending recomputations present")
+
+    elif num_run < threshold:
+    	log.info("Below threshold; recomputation is about to be executed...")
+    	pen_recalc = col.find_one({"s":"pending"})
+    	pen_recalc_id = str(pen_recalc["_id"])
+    	col.update({ "_id": ObjectId(pen_recalc_id) }, { "$set": { "s": "running" } })
+
+        # TODO: placeholder: call recomputation executor.
+
+    else:
+    	log.info("Over threshold; no recomputation will be executed.")
+
+if __name__ == "__main__":
+
+    # Feed Argument parser with the description
+    # No arguments needed
+    arg_parser = ArgumentParser(
+        description="Polling for pending recomputations requests")
+    
+    # Parse the command line arguments accordingly and introduce them to
+    # main...
+    sys.exit(main(arg_parser.parse_args()))

--- a/bin/test_poller.py
+++ b/bin/test_poller.py
@@ -1,0 +1,37 @@
+from mock import MagicMock, patch
+
+from poller_ar import run_recomputation, main, ObjectId
+
+
+def test_run_recomputation():
+    """
+    Check that the recomputation function looks for a single pending
+    request and submits it to be recomputed
+    """
+    pen_recalc, col = MagicMock(), MagicMock()
+    pen_recalc.__getitem__.return_value = ObjectId('5559ed3306f6233c190bc851')
+    col.find_one.return_value = pen_recalc
+    run_recomputation(col)
+    col.find_one.assert_called_with({'s': 'pending'})
+    col.update.assert_called_with({'_id': ObjectId('5559ed3306f6233c190bc851')}, {'$set': {'s': 'running'}})
+    #TODO: when the actual recomputation call is implemented, add some kind of test
+
+
+def test_main():
+    """
+    Check that the recomputation is called if the threshold of
+    running recomputations is not exceeded
+    """
+    with patch('poller_ar.get_poller_config', return_value=[MagicMock()]*4) as get_poller_config,\
+         patch('poller_ar.get_mongo_collection') as get_mongo_collection, \
+         patch('poller_ar.get_pending_and_running', return_value=[MagicMock()]*2) as get_pending_and_running,\
+         patch('poller_ar.run_recomputation') as run_recomputation:
+        get_pending_and_running.return_value[1] = 2
+        get_poller_config.return_value[3] = 3
+        main()
+        run_recomputation.assert_called_once_with(get_mongo_collection.return_value)
+
+
+if __name__ == '__main__':
+    test_run_recomputation()
+    test_main()

--- a/conf/ar-compute-engine.conf
+++ b/conf/ar-compute-engine.conf
@@ -18,6 +18,8 @@ serialization=none
 prefilter_clean=true
 sync_clean=true
 
+# Provide maximum number of recomputations that can run in parallel.
+recomp_threshold=1
 
 [logging]
 


### PR DESCRIPTION
This is an initial implementation of poller. The poller gets from mongodb the number of recomputations 'pending' and recomputations 'running', while the maximum number of recomputations (threshold) that can be run in parallel is provided by the compute engine's configuration file.  In this first commit this threshold is set to 1. 

Few words about the logic:
* When there are no 'pending' recomputation requests,  the program exits.
* If the threshold had not been reached, the poller retrieves from mongodb the first recomputation request's id (which shall be passed to the recomputation executor) that is in state 'pending' and changes status to running. There is a "TODO" in comment, waiting for the actual recomputation executor to be written. 
* If the threshold had been reached, the program exits.

Few more comments:
* Logging is enabled in info level for all cases.
* A cron job needs to be written so that the poller will run periodically.