### PR TITLE
ARGO-125 Changed 'none' to None for log_file name

### DIFF
--- a/bin/argolog.py
+++ b/bin/argolog.py
@@ -25,7 +25,7 @@ def init_log(log_mode, log_file, log_level, log_name):
 
     # If log_mode = file then setup a file handler
     if log_mode == 'file':
-
+        assert log_file is not None
         file_log = logging.FileHandler(log_file)
         file_format = logging.Formatter(
             '%(asctime)s [%(name)s] %(levelname)s %(message)s')

--- a/bin/job_ar.py
+++ b/bin/job_ar.py
@@ -34,7 +34,7 @@ def main(args=None):
 
     # Initialize logging
     log_mode = ArConfig.get('logging', 'log_mode')
-    log_file = 'none'
+    log_file = None
 
     if log_mode == 'file':
         log_file = ArConfig.get('logging', 'log_file')

--- a/bin/job_cycle.py
+++ b/bin/job_cycle.py
@@ -21,7 +21,7 @@ def main(args=None):
 
     # Initialize logging
     log_mode = ArConfig.get('logging', 'log_mode')
-    log_file = 'none'
+    log_file = None
 
     if log_mode == 'file':
         log_file = ArConfig.get('logging', 'log_file')

--- a/bin/job_status_detail.py
+++ b/bin/job_status_detail.py
@@ -33,7 +33,7 @@ def main(args=None):
 
     # Initialize logging
     log_mode = ArConfig.get('logging', 'log_mode')
-    log_file = 'none'
+    log_file = None
 
     if log_mode == 'file':
         log_file = ArConfig.get('logging', 'log_file')

--- a/bin/mongo_clean_ar.py
+++ b/bin/mongo_clean_ar.py
@@ -19,7 +19,7 @@ def main(args=None):
 
     # Initialize logging
     log_mode = ArConfig.get('logging', 'log_mode')
-    log_file = 'none'
+    log_file = None
 
     if log_mode == 'file':
         log_file = ArConfig.get('logging', 'log_file')

--- a/bin/mongo_clean_status.py
+++ b/bin/mongo_clean_status.py
@@ -19,7 +19,7 @@ def main(args=None):
 
     # Initialize logging
     log_mode = ArConfig.get('logging', 'log_mode')
-    log_file = 'none'
+    log_file = None
 
     if log_mode == 'file':
         log_file = ArConfig.get('logging', 'log_file')

--- a/bin/sync_backup.py
+++ b/bin/sync_backup.py
@@ -27,7 +27,7 @@ def main(args=None):
 
     # Initialize logging
     log_mode = ArConfig.get('logging', 'log_mode')
-    log_file = 'none'
+    log_file = None
 
     if log_mode == 'file':
         log_file = ArConfig.get('logging', 'log_file')

--- a/bin/upload_metric.py
+++ b/bin/upload_metric.py
@@ -28,7 +28,7 @@ def main(args=None):
 
     # Initialize logging
     log_mode = ArConfig.get('logging', 'log_mode')
-    log_file = 'none'
+    log_file = None
 
     if log_mode == 'file':
         log_file = ArConfig.get('logging', 'log_file')

--- a/bin/upload_sync.py
+++ b/bin/upload_sync.py
@@ -51,7 +51,7 @@ def main(args=None):
 
     # Initialize logging
     log_mode = ArConfig.get('logging', 'log_mode')
-    log_file = 'none'
+    log_file = None
 
     if log_mode == 'file':
         log_file = ArConfig.get('logging', 'log_file')


### PR DESCRIPTION
The default value for log_file in the python scripts was 'none' (type string) so when no log_file was set, a new log_file was created with the name 'none'. 

Changed it to None and added assertion when initializing a logger