### PR TITLE
ARGO-125 Changed 'none' to None for log_file name

### DIFF
--- a/ar-compute.spec
+++ b/ar-compute.spec
@@ -1,7 +1,7 @@
 Name: ar-compute
 Summary: A/R Comp Engine core scripts
-Version: 1.6.1
-Release: 5%{?dist}
+Version: 1.6.2
+Release: 1%{?dist}
 License: ASL 2.0
 Buildroot: %{_tmppath}/%{name}-buildroot
 Group:     EGI/SA4
@@ -65,6 +65,10 @@ mvn clean
 %attr(0644,root,root) /etc/ar-compute/*.json
 
 %changelog
+* Thu May 28 2015 Avraam Tsantekidis <avraamt@grid.auth.gr> - 1.6.2-1%{?dist}
+- ARGO-125 Added test for raising TypeError
+- ARGO-125 changed assertion to exception
+- ARGO-125 Changed 'none' to None for log_file name
 * Thu May 14 2015 Konstantinos Kagkelidis <kaggis@gmail.com> - 1.6.1-5%{?dist}
 - ARGO-118 Reading new avro "tags" field type as map
 - ARGO-48 Add logging to the data model classes

--- a/bin/argolog.py
+++ b/bin/argolog.py
@@ -25,7 +25,8 @@ def init_log(log_mode, log_file, log_level, log_name):
 
     # If log_mode = file then setup a file handler
     if log_mode == 'file':
-        assert log_file is not None
+        if log_file is None:
+            raise TypeError("Log filename is NoneType")
         file_log = logging.FileHandler(log_file)
         file_format = logging.Formatter(
             '%(asctime)s %(name)s[%(process)d]: %(levelname)s %(message)s')

--- a/bin/argolog.py
+++ b/bin/argolog.py
@@ -25,7 +25,7 @@ def init_log(log_mode, log_file, log_level, log_name):
 
     # If log_mode = file then setup a file handler
     if log_mode == 'file':
-
+        assert log_file is not None
         file_log = logging.FileHandler(log_file)
         file_format = logging.Formatter(
             '%(asctime)s %(name)s[%(process)d]: %(levelname)s %(message)s')

--- a/bin/job_ar.py
+++ b/bin/job_ar.py
@@ -36,7 +36,7 @@ def main(args=None):
 
     # Initialize logging
     log_mode = ArConfig.get('logging', 'log_mode')
-    log_file = 'none'
+    log_file = None
 
     if log_mode == 'file':
         log_file = ArConfig.get('logging', 'log_file')

--- a/bin/job_cycle.py
+++ b/bin/job_cycle.py
@@ -21,7 +21,7 @@ def main(args=None):
 
     # Initialize logging
     log_mode = ArConfig.get('logging', 'log_mode')
-    log_file = 'none'
+    log_file = None
 
     if log_mode == 'file':
         log_file = ArConfig.get('logging', 'log_file')

--- a/bin/job_status_detail.py
+++ b/bin/job_status_detail.py
@@ -35,7 +35,7 @@ def main(args=None):
 
     # Initialize logging
     log_mode = ArConfig.get('logging', 'log_mode')
-    log_file = 'none'
+    log_file = None
 
     if log_mode == 'file':
         log_file = ArConfig.get('logging', 'log_file')

--- a/bin/mongo_clean_ar.py
+++ b/bin/mongo_clean_ar.py
@@ -19,7 +19,7 @@ def main(args=None):
 
     # Initialize logging
     log_mode = ArConfig.get('logging', 'log_mode')
-    log_file = 'none'
+    log_file = None
 
     if log_mode == 'file':
         log_file = ArConfig.get('logging', 'log_file')

--- a/bin/mongo_clean_status.py
+++ b/bin/mongo_clean_status.py
@@ -19,7 +19,7 @@ def main(args=None):
 
     # Initialize logging
     log_mode = ArConfig.get('logging', 'log_mode')
-    log_file = 'none'
+    log_file = None
 
     if log_mode == 'file':
         log_file = ArConfig.get('logging', 'log_file')

--- a/bin/sync_backup.py
+++ b/bin/sync_backup.py
@@ -28,7 +28,7 @@ def main(args=None):
 
     # Initialize logging
     log_mode = ArConfig.get('logging', 'log_mode')
-    log_file = 'none'
+    log_file = None
 
     if log_mode == 'file':
         log_file = ArConfig.get('logging', 'log_file')

--- a/bin/test_argolog.py
+++ b/bin/test_argolog.py
@@ -1,0 +1,10 @@
+import pytest
+
+from argolog import init_log
+
+
+def test_init_log_raise_on_none_filename():
+    with pytest.raises(TypeError) as excinfo:
+        init_log(log_mode='file', log_file=None, log_level='INFO', log_name='argo.test')
+    assert "Log filename is NoneType" in str(excinfo.value)
+

--- a/bin/upload_metric.py
+++ b/bin/upload_metric.py
@@ -31,7 +31,7 @@ def main(args=None):
 
     # Initialize logging
     log_mode = ArConfig.get('logging', 'log_mode')
-    log_file = 'none'
+    log_file = None
 
     if log_mode == 'file':
         log_file = ArConfig.get('logging', 'log_file')

--- a/bin/upload_sync.py
+++ b/bin/upload_sync.py
@@ -53,7 +53,7 @@ def main(args=None):
 
     # Initialize logging
     log_mode = ArConfig.get('logging', 'log_mode')
-    log_file = 'none'
+    log_file = None
 
     if log_mode == 'file':
         log_file = ArConfig.get('logging', 'log_file')


### PR DESCRIPTION
The default value for log_file in the python scripts was 'none' (type string) so when no log_file was set, a new log_file was created with the name 'none'.

Changed default values to None and added assertion when initializing the logger