### PR TITLE
Modified .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+*.pyc


### PR DESCRIPTION
Unit tests generate files with pyc extension that should not be tracked. This PR fixes this. 