### PR TITLE
ARGO-129 - bugfix - Argo connector path reference fix (in recomputation scripts)

### DIFF
--- a/ar-compute.spec
+++ b/ar-compute.spec
@@ -1,7 +1,7 @@
 Name: ar-compute
 Summary: A/R Comp Engine core scripts
 Version: 1.6.2
-Release: 2%{?dist}
+Release: 3%{?dist}
 License: ASL 2.0
 Buildroot: %{_tmppath}/%{name}-buildroot
 Group:     EGI/SA4
@@ -65,6 +65,8 @@ mvn clean
 %attr(0644,root,root) /etc/ar-compute/*.json
 
 %changelog
+* Wed Jun 4 2015 Konstantinos Kagkelidis <kaggis@gmail.com> - 1.6.2-3%{?dist}
+- ARGO-129 Bugfix: Fix reference to connector path
 * Wed Jun 3 2015 Konstantinos Kagkelidis <kaggis@gmail.com> - 1.6.2-2%{?dist}
 - ARGO-74 Implement recomputation execution
 - ARGO-75 Implement changes in recomputation state

--- a/bin/mongo_recompute.py
+++ b/bin/mongo_recompute.py
@@ -81,7 +81,7 @@ def main(args=None):
 
     # default paths
     fn_ar_cfg = "/etc/ar-compute-engine.conf"
-    arsync_lib = "/var/lib/ar-sync/"
+    
 
     # Init configuration
     cfg = ArgoConfiguration(fn_ar_cfg)
@@ -97,7 +97,7 @@ def main(args=None):
     log.info("Date: %s, relevant recomputations found: %s", args.date, len(results))
 
     # Write results to file
-    write_output(results, args.tenant, get_date_under(args.date), arsync_lib)
+    write_output(results, args.tenant, get_date_under(args.date), cfg.sync_path)
 
 
 if __name__ == "__main__":

--- a/bin/upload_sync.py
+++ b/bin/upload_sync.py
@@ -125,7 +125,7 @@ def main(args=None):
     local_aps = os.path.join(arcomp_conf, fn_aps)
     local_ops = os.path.join(arcomp_conf, fn_ops)
     local_cfg = os.path.join(arcomp_conf, fn_cfg)
-    local_rec = os.path.join(arcomp_conf, fn_rec)
+    local_rec = os.path.join(arsync_lib, fn_rec)
 
     # Check filenames if exist
     log.info("Check if %s exists: %s", local_aps, os.path.exists(local_aps))

--- a/bin/utils.py
+++ b/bin/utils.py
@@ -17,6 +17,9 @@ class ArgoConfiguration(object):
     # Tenant parameters
     tenants = []
     jobs = defaultdict(list)
+    # connector parameters
+    sync_exec = None
+    sync_path = None
 
     def __init__(self, filename):
 
@@ -53,6 +56,10 @@ class ArgoConfiguration(object):
             job_set = job_set.split(',')
             for job_item in job_set:
                 self.jobs[tenant_item].append(job_item)
+        
+        # Grab connector sync path
+        self.sync_exec = ar_config.get('connectors','sync_exec')
+        self.sync_path = ar_config.get('connectors','sync_path')
 
 
 def get_date_under(date):

--- a/bin/utils_test.py
+++ b/bin/utils_test.py
@@ -17,6 +17,10 @@ log_level=debug
 tenants=TenantA,TenantB
 TenantA_jobs=JobA,JobB
 TenantB_jobs=JobC,JobD
+
+[connectors]
+sync_exec=/usr/libexec/argo-egi-connectors
+sync_path=/var/lib/argo-connectors
 """
 
 
@@ -71,3 +75,6 @@ def test_load_configuration(tmpdir):
 
     assert cfg.tenants == expected_tenants
     assert cfg.jobs == expected_jobs
+
+    assert cfg.sync_exec == "/usr/libexec/argo-egi-connectors"
+    assert cfg.sync_path == "/var/lib/argo-connectors"


### PR DESCRIPTION
There was a deprecated reference to the argo-connector path (arsync, now it's argo-connectors).
The reference is now retrieved from the configuration file 

please review 
/cc @pkoro 