### PR TITLE
ARGO-155 Align CE output fields with new mongodb schema

### DIFF
--- a/bin/job_ar.py
+++ b/bin/job_ar.py
@@ -90,16 +90,11 @@ def main(args=None):
     pig_params['dt'] = args.date
     pig_params['mode'] = mode
     pig_params['name_eg'] = json_cfg['egroup']
-    pig_params['name_sg'] = json_cfg['ggroup']
-    pig_params['n_alt'] = cfg.n_alt
     pig_params['s_period'] = cfg.sampling_period
     pig_params['s_interval'] = cfg.sampling_interval
-    pig_params['e_map'] = cfg.e_map
-    pig_params['s_map'] = cfg.s_map
     pig_params['flt'] = '1'
-    # collection names are temporarily matching old schema. will be updated in ARGO-153
-    pig_params['mongo_service'] = cfg.get_mongo_uri('service_ar')
-    pig_params['mongo_egroup'] = cfg.get_mongo_uri('endpoint_group_ar')
+    pig_params['mongo_service'] = cfg.get_mongo_uri('ar', 'service_ar')
+    pig_params['mongo_egroup'] = cfg.get_mongo_uri('ar', 'endpoint_group_ar')
 
     cmd_pig = []
 

--- a/bin/job_status_detail.py
+++ b/bin/job_status_detail.py
@@ -78,13 +78,8 @@ def main(args=None):
     pig_params['aps'] = cfg_path + args.tenant + '_' + job_set[0] + '_ap.json'
     pig_params['dt'] = args.date
     pig_params['mode'] = mode
-    pig_params['n_eg'] = ArConfig.get('datastore_mapping', 'n_eg')
-    pig_params['n_gg'] = ArConfig.get('datastore_mapping', 'n_gg')
-    pig_params['n_alt'] = ArConfig.get('datastore_mapping', 'n_alt')
-    pig_params['n_altf'] = ArConfig.get('datastore_mapping', 'n_altf')
-    pig_params['sd_map'] = ArConfig.get('datastore_mapping', 'sd_map')
     pig_params['flt'] = '0'
-    pig_params['mongo_status_detail'] = cfg.get_mongo_uri('status_metric')
+    pig_params['mongo_status_detail'] = cfg.get_mongo_uri('status', 'status_metric')
 
     cmd_pig = []
 

--- a/bin/utils.py
+++ b/bin/utils.py
@@ -22,10 +22,6 @@ class ArgoConfiguration(object):
     sync_path = None
     # ce run mode
     mode = None
-    # datastore mapping
-    n_alt = None
-    e_map = None
-    s_map = None
     # sampling
     sampling_period = None
     sampling_interval = None
@@ -76,11 +72,6 @@ class ArgoConfiguration(object):
 
         # Grab run mode
         self.mode = ar_config.get('default', 'mode')
-
-        # Grab mapping info (will be removed in the near future)
-        self.n_alt = ar_config.get('datastore_mapping', 'n_alt')
-        self.e_map = ar_config.get('datastore_mapping', 'e_map')
-        self.s_map = ar_config.get('datastore_mapping', 's_map')
 
         # Grab sampling parameters
         self.sampling_period = ar_config.get('sampling', 's_period')

--- a/bin/utils.py
+++ b/bin/utils.py
@@ -29,7 +29,9 @@ class ArgoConfiguration(object):
     # sampling
     sampling_period = None
     sampling_interval = None
-
+    # clean
+    sync_clean = None
+    prefilter_clean = None
     # tenant ar store configuration
     tenant_db_conf = {}
 
@@ -83,6 +85,10 @@ class ArgoConfiguration(object):
         # Grab sampling parameters
         self.sampling_period = ar_config.get('sampling', 's_period')
         self.sampling_interval = ar_config.get('sampling', 's_interval')
+
+        # Grab clean parameters
+        self.prefilter_clean = ar_config.get('default', 'prefilter_clean')
+        self.sync_clean = ar_config.get('default', 'sync_clean')
 
     def load_tenant_db_conf(self, filename):
         """

--- a/bin/utils_test.py
+++ b/bin/utils_test.py
@@ -8,6 +8,9 @@ mongo_host=127.0.0.1
 mongo_port=27017
 mode=local
 
+prefilter_clean=true
+sync_clean=true
+
 [logging]    
 log_mode=file
 log_file=/var/log/ar-compute.log

--- a/conf/ar-compute-engine.conf
+++ b/conf/ar-compute-engine.conf
@@ -79,17 +79,3 @@ EGI_prefilter=prefilter-egi.py
 
 s_period=1440
 s_interval=5
-
-
-[datastore_mapping]
-
-e_map=dt,ap,p,s,n,hs,a,r,up,u,d,m,pr,ss,cs,i,sc
-s_map=dt,ap,p,s,n,sf,a,r,up,u,d,m,pr,ss,cs,i,sc
-sd_map=ts,s,sum,msg,ps,pts,di,ti
-n_eg=site
-n_gg=roc
-n_alt=vo
-n_altf=vof
-service_dest=AR.sfreports
-egroup_dest=AR.sites
-sdetail_dest = AR.status_metric

--- a/status-computation/java/src/main/java/ar/GroupEndpointMap.java
+++ b/status-computation/java/src/main/java/ar/GroupEndpointMap.java
@@ -172,38 +172,22 @@ public class GroupEndpointMap extends EvalFunc<Tuple> {
 		int weightVal = this.weightMgr.getWeight(weightType, egroupName);
 
 		String ggroupName = this.ggMgr.getGroup(ggroupType, egroupName);
-		String avProfile = this.apsMgr.getAvProfiles().get(0);
-		String avNamespace = this.apsMgr.getProfileNamespace(avProfile);
-		String metricProfile = this.apsMgr.getProfileMetricProfile(avProfile);
-		String fullAvProfile = avNamespace + "-" + avProfile;
+
 		// Add the previous info before adding the tags
-		output.append(dateInt); // 0
-		output.append(fullAvProfile); // 1
-		output.append(metricProfile); // 2
-		output.append(egroupName); // 3
-		output.append(ggroupName); // 4
-		output.append(weightVal); // 5
+		output.append(dateInt); 				// 0 - date
+		output.append(egroupName); 				// 1 - name
+		output.append(ggroupName); 				// 2 - supergroup 
+		output.append(weightVal); 				// 4 - weight
 
 		// Add the a/r info
-		output.append(av); // 6
-		output.append(rel); // 7
-		output.append(upFraction); // 8
-		output.append(unknownFraction); // 9
-		output.append(downFraction); // 10
-
-		// Get egroup config tags
-		for (Entry<String, String> item : this.cfgMgr.egroupTags.entrySet()) {
-			output.append(item.getValue());
-		}
-
-		HashMap<String, String> ggTags = this.ggMgr.getGroupTags(ggroupType, egroupName);
-
-		// Get ggroup config tags
-		for (Entry<String, String> item : this.cfgMgr.ggroupTags.entrySet()) {
-			String curValue = ggTags.get(item.getKey());
-			output.append(curValue);
-		}
-
+		output.append(av); 						// 5 - availability  
+		output.append(rel); 					// 6 - reliability 
+		output.append(upFraction); 				// 7 - up 
+		output.append(downFraction); 			// 8 - down
+		output.append(unknownFraction); 		// 9 - unknown 
+	
+		// NOTE: tags will be handled properly in a later PR
+		
 		return output;
 	}
 
@@ -225,11 +209,7 @@ public class GroupEndpointMap extends EvalFunc<Tuple> {
 		// Define first fields
 		Schema.FieldSchema sDateInt = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "date"),
 				DataType.INTEGER);
-		Schema.FieldSchema sAvProfile = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "av_profile"),
-				DataType.CHARARRAY);
-		Schema.FieldSchema sMetricProfile = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "metric_profile"),
-				DataType.CHARARRAY);
-		Schema.FieldSchema sGroup = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "group"),
+		Schema.FieldSchema sName = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "group"),
 				DataType.CHARARRAY);
 		Schema.FieldSchema sSuperGroup = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "supergroup"),
 				DataType.CHARARRAY);
@@ -240,52 +220,27 @@ public class GroupEndpointMap extends EvalFunc<Tuple> {
 				DataType.DOUBLE);
 		Schema.FieldSchema sRel = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "reliability"),
 				DataType.DOUBLE);
-		Schema.FieldSchema sUp = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "up_f"), DataType.DOUBLE);
-		Schema.FieldSchema sUnknown = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "unknown_f"),
+		Schema.FieldSchema sUp = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "up"), DataType.DOUBLE);
+		Schema.FieldSchema sDown = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "down"), DataType.DOUBLE);
+		Schema.FieldSchema sUnknown = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "unknown"),
 				DataType.DOUBLE);
-		Schema.FieldSchema sDown = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "down_f"), DataType.DOUBLE);
+		
+		// NOTE: tags will be handled properly in a later PR
 
-		// Create a field schema list for egroup tags
-		ArrayList<Schema.FieldSchema> egroupFields = new ArrayList<Schema.FieldSchema>();
-		// Get egroup config tags
-		for (Entry<String, String> item : this.localCfgMgr.egroupTags.entrySet()) {
-			egroupFields.add(
-					new Schema.FieldSchema(this.localCfgMgr.getMapped("egroups", item.getKey()), DataType.CHARARRAY));
-		}
-
-		ArrayList<Schema.FieldSchema> ggroupFields = new ArrayList<Schema.FieldSchema>();
-		// Get ggroup config tags
-		for (Entry<String, String> item : this.localCfgMgr.ggroupTags.entrySet()) {
-			ggroupFields.add(
-					new Schema.FieldSchema(this.localCfgMgr.getMapped("ggroups", item.getKey()), DataType.CHARARRAY));
-		}
 
 		// Add fields to schema
 		groupEndpointData.add(sDateInt);
-		groupEndpointData.add(sAvProfile);
-		groupEndpointData.add(sMetricProfile);
-		groupEndpointData.add(sGroup);
+		groupEndpointData.add(sName);
 		groupEndpointData.add(sSuperGroup);
 		groupEndpointData.add(sWeight);
 
 		groupEndpointData.add(sAv);
 		groupEndpointData.add(sRel);
 		groupEndpointData.add(sUp);
-		groupEndpointData.add(sUnknown);
 		groupEndpointData.add(sDown);
-
-		for (Schema.FieldSchema item : egroupFields) {
-			groupEndpointData.add(item);
-		}
-
-		for (Schema.FieldSchema item : ggroupFields) {
-			groupEndpointData.add(item);
-		}
+		groupEndpointData.add(sUnknown);
 
 		return groupEndpointData;
-
-		// return null;
-
 	}
 
 }

--- a/status-computation/java/src/main/java/ar/ServiceMap.java
+++ b/status-computation/java/src/main/java/ar/ServiceMap.java
@@ -170,32 +170,19 @@ public class ServiceMap extends EvalFunc<Tuple> {
 		String metricProfile = this.apsMgr.getProfileMetricProfile(avProfile);
 		String fullAvProfile = avNamespace + "-" + avProfile;
 		// Add the previous info before adding the tags
-		output.append(dateInt); // 0
-		output.append(fullAvProfile); // 1
-		output.append(metricProfile); // 2
-		output.append(egroupName); // 3
-		output.append(ggroupName); // 4
-		output.append(service); // 5
+		
+		output.append(dateInt); 			// 0 - date
+		output.append(service); 			// 1 - name
+		output.append(egroupName); 			// 2 - supergroup 
 
 		// Add the a/r info
-		output.append(av); // 6
-		output.append(rel); // 7
-		output.append(upFraction); // 8
-		output.append(unknownFraction); // 9
-		output.append(downFraction); // 10
+		output.append(av); 					// 3 - availability 
+		output.append(rel); 				// 4 - reliability 
+		output.append(upFraction); 			// 5 - up fraction
+		output.append(downFraction); 		// 6 - down fraction
+		output.append(unknownFraction); 	// 7 - unknown fraction 
 
-		// Get egroup config tags
-		for (Entry<String, String> item : this.cfgMgr.egroupTags.entrySet()) {
-			output.append(item.getValue());
-		}
-
-		HashMap<String, String> ggTags = this.ggMgr.getGroupTags(ggroupType, egroupName);
-
-		// Get ggroup config tags
-		for (Entry<String, String> item : this.cfgMgr.ggroupTags.entrySet()) {
-			String curValue = ggTags.get(item.getKey());
-			output.append(curValue);
-		}
+		// NOTE: tags will be handled properly in a later PR
 
 		return output;
 	}
@@ -218,62 +205,35 @@ public class ServiceMap extends EvalFunc<Tuple> {
 		// Define first fields
 		Schema.FieldSchema sDateInt = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "date"),
 				DataType.INTEGER);
-		Schema.FieldSchema sAvProfile = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "av_profile"),
-				DataType.CHARARRAY);
-		Schema.FieldSchema sMetricProfile = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "metric_profile"),
-				DataType.CHARARRAY);
-		Schema.FieldSchema sGroup = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "group"),
+		Schema.FieldSchema sName = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "name"),
 				DataType.CHARARRAY);
 		Schema.FieldSchema sSuperGroup = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "supergroup"),
 				DataType.CHARARRAY);
-		Schema.FieldSchema sService = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "service"),
-				DataType.CHARARRAY);
+		
 		// Define the ar results fields
-		Schema.FieldSchema sAv = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "availability"),
+		Schema.FieldSchema sAvailability = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "availability"),
 				DataType.DOUBLE);
-		Schema.FieldSchema sRel = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "reliability"),
+		Schema.FieldSchema sReliability = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "reliability"),
 				DataType.DOUBLE);
-		Schema.FieldSchema sUp = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "up_f"), DataType.DOUBLE);
-		Schema.FieldSchema sUnknown = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "unknown_f"),
+		Schema.FieldSchema sUp = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "up"), DataType.DOUBLE);
+		Schema.FieldSchema sDown = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "down"), DataType.DOUBLE);
+		Schema.FieldSchema sUnknown = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "unknown"),
 				DataType.DOUBLE);
-		Schema.FieldSchema sDown = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "down_f"), DataType.DOUBLE);
-
-		// Create a field schema list for egroup tags
-		ArrayList<Schema.FieldSchema> egroupFields = new ArrayList<Schema.FieldSchema>();
-		// Get egroup config tags
-		for (Entry<String, String> item : this.localCfgMgr.egroupTags.entrySet()) {
-			egroupFields.add(
-					new Schema.FieldSchema(this.localCfgMgr.getMapped("egroups", item.getKey()), DataType.CHARARRAY));
-		}
-
-		ArrayList<Schema.FieldSchema> ggroupFields = new ArrayList<Schema.FieldSchema>();
-		// Get ggroup config tags
-		for (Entry<String, String> item : this.localCfgMgr.ggroupTags.entrySet()) {
-			ggroupFields.add(
-					new Schema.FieldSchema(this.localCfgMgr.getMapped("ggroups", item.getKey()), DataType.CHARARRAY));
-		}
+		
+		// NOTE: tags and tag schema will be handled properly in a later PR
 
 		// Add fields to schema
-		serviceData.add(sDateInt);
-		serviceData.add(sAvProfile);
-		serviceData.add(sMetricProfile);
-		serviceData.add(sGroup);
-		serviceData.add(sSuperGroup);
-		serviceData.add(sService);
+		serviceData.add(sDateInt); // 0 - date
+		serviceData.add(sName); // 
+		serviceData.add(sSuperGroup); // 1 - name
 
-		serviceData.add(sAv);
-		serviceData.add(sRel);
+
+		serviceData.add(sAvailability);
+		serviceData.add(sReliability);
 		serviceData.add(sUp);
 		serviceData.add(sUnknown);
 		serviceData.add(sDown);
 
-		for (Schema.FieldSchema item : egroupFields) {
-			serviceData.add(item);
-		}
-
-		for (Schema.FieldSchema item : ggroupFields) {
-			serviceData.add(item);
-		}
 
 		return serviceData;
 

--- a/status-computation/java/src/main/java/status/PrepStatusDetails.java
+++ b/status-computation/java/src/main/java/status/PrepStatusDetails.java
@@ -158,7 +158,7 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 		// add stuff to the output
 
 		output.append(monitoring_host);
-		output.append(service);
+		output.append(service);		   
 		output.append(hostname);
 		output.append(metric);
 		output.append(outBag);
@@ -170,7 +170,7 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 	@Override
 	public Schema outputSchema(Schema input) {
 
-		Schema.FieldSchema monitoring_box = new Schema.FieldSchema("monitoring_host", DataType.CHARARRAY);
+		Schema.FieldSchema monitoring_box = new Schema.FieldSchema("monitoring_box", DataType.CHARARRAY);
 		Schema.FieldSchema hostname = new Schema.FieldSchema("hostname", DataType.CHARARRAY);
 		Schema.FieldSchema service_type = new Schema.FieldSchema("service", DataType.CHARARRAY);
 		Schema.FieldSchema metric = new Schema.FieldSchema("metric", DataType.CHARARRAY);

--- a/status-computation/java/src/main/java/status/PrepStatusDetails.java
+++ b/status-computation/java/src/main/java/status/PrepStatusDetails.java
@@ -155,23 +155,12 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 			}
 		}
 
-		// Find egroup and gggroup
-
-		String egroupType = this.cfgMgr.egroup;
-		String egroupName = this.egrpMgr.getGroup(egroupType, hostname, service);
-		String ggroupType = this.cfgMgr.ggroup;
-		String ggroupName = this.ggrpMgr.getGroup(ggroupType, egroupName);
-
 		// add stuff to the output
 
 		output.append(monitoring_host);
 		output.append(service);
 		output.append(hostname);
 		output.append(metric);
-		output.append(ggroupName);
-		output.append(egroupName);
-		output.append(this.cfgMgr.agroup);
-		output.append(this.cfgMgr.agroup);
 		output.append(outBag);
 
 		return output;
@@ -185,19 +174,15 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 		Schema.FieldSchema hostname = new Schema.FieldSchema("hostname", DataType.CHARARRAY);
 		Schema.FieldSchema service_type = new Schema.FieldSchema("service", DataType.CHARARRAY);
 		Schema.FieldSchema metric = new Schema.FieldSchema("metric", DataType.CHARARRAY);
-		Schema.FieldSchema ggroup = new Schema.FieldSchema("ggroup", DataType.CHARARRAY);
-		Schema.FieldSchema egroup = new Schema.FieldSchema("egroup", DataType.CHARARRAY);
-		Schema.FieldSchema altgroup = new Schema.FieldSchema("altg", DataType.CHARARRAY);
-		Schema.FieldSchema altgroupf = new Schema.FieldSchema("altgf", DataType.CHARARRAY);
 
 		Schema.FieldSchema timestamp = new Schema.FieldSchema("timestamp", DataType.CHARARRAY);
 		Schema.FieldSchema status = new Schema.FieldSchema("status", DataType.CHARARRAY);
 		Schema.FieldSchema summary = new Schema.FieldSchema("summary", DataType.CHARARRAY);
 		Schema.FieldSchema message = new Schema.FieldSchema("message", DataType.CHARARRAY);
-		Schema.FieldSchema prev_state = new Schema.FieldSchema("prev_state", DataType.CHARARRAY);
-		Schema.FieldSchema prev_ts = new Schema.FieldSchema("prev_ts", DataType.CHARARRAY);
-		Schema.FieldSchema date_int = new Schema.FieldSchema("date_int", DataType.INTEGER);
-		Schema.FieldSchema time_int = new Schema.FieldSchema("time_int", DataType.INTEGER);
+		Schema.FieldSchema prev_state = new Schema.FieldSchema("previous_state", DataType.CHARARRAY);
+		Schema.FieldSchema prev_ts = new Schema.FieldSchema("previous_timestamp", DataType.CHARARRAY);
+		Schema.FieldSchema date_int = new Schema.FieldSchema("date_integer", DataType.INTEGER);
+		Schema.FieldSchema time_int = new Schema.FieldSchema("time_integer", DataType.INTEGER);
 
 		Schema status_metric = new Schema();
 		Schema timeline = new Schema();
@@ -206,11 +191,6 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 		status_metric.add(service_type);
 		status_metric.add(hostname);
 		status_metric.add(metric);
-		status_metric.add(egroup);
-		status_metric.add(ggroup);
-
-		status_metric.add(altgroup);
-		status_metric.add(altgroupf);
 
 		timeline.add(timestamp);
 		timeline.add(status);

--- a/status-computation/pig/compute-ar.pig
+++ b/status-computation/pig/compute-ar.pig
@@ -63,8 +63,8 @@ endpoint_groups = FOREACH (GROUP service_flavors BY (groupname)) {
 
 service_ar = FOREACH service_flavors GENERATE FLATTEN(f_ServiceAR(groupname,service,timeline));
 endpoint_groups_ar = FOREACH endpoint_groups GENERATE FLATTEN(f_EndpointGroupAR(groupname,timeline)) as (groupname,availability,reliability,up_f,unknown_f,down_f);
-service_data = FOREACH service_ar GENERATE FLATTEN(f_ServiceDATA(service,groupname,availability,reliability,up_f,unknown_f,down_f)) AS ($s_map);
-endpoint_groups_data = FOREACH endpoint_groups_ar GENERATE FLATTEN(f_egroupDATA(groupname,availability,reliability,up_f,unknown_f,down_f)) AS ($e_map); 
+service_data = FOREACH service_ar GENERATE FLATTEN(f_ServiceDATA(service,groupname,availability,reliability,up_f,unknown_f,down_f)) AS (date,name,supergroup,availability,reliability,up,down,unknown);
+endpoint_groups_data = FOREACH endpoint_groups_ar GENERATE FLATTEN(f_egroupDATA(groupname,availability,reliability,up_f,unknown_f,down_f)) AS (date,name,supergroup,weight,availability,reliability,up,down,uknown); 
 
 STORE service_data INTO '$mongo_service' USING com.mongodb.hadoop.pig.MongoInsertStorage();
 STORE endpoint_groups_data INTO '$mongo_egroup' USING com.mongodb.hadoop.pig.MongoInsertStorage();

--- a/status-computation/pig/compute-status.pig
+++ b/status-computation/pig/compute-status.pig
@@ -42,7 +42,7 @@ status_detail =	FOREACH  (GROUP mdata_full BY (monitoring_host,service,hostname,
 	GENERATE  FLATTEN( f_PrepStatus(group.monitoring_host, group.service, group.hostname, group.metric, t.(timestamp,status,summary,message)) );
 };
 
-status_unwrap = FOREACH status_detail GENERATE $0 as monitoring_box, $1 as service, $2 as host, $3 as metric, FLATTEN($8) as (timestamp,status,summary,message,previous_state,previous_timestamp,date_integer,time_integer);
+status_unwrap = FOREACH status_detail GENERATE $0 as monitoring_box, $1 as service, $2 as host, $3 as metric, FLATTEN($4) as (timestamp,status,summary,message,previous_state,previous_timestamp,date_integer,time_integer);
 describe status_unwrap;
 STORE status_unwrap INTO '$mongo_status_detail' USING com.mongodb.hadoop.pig.MongoInsertStorage();
 

--- a/status-computation/pig/compute-status.pig
+++ b/status-computation/pig/compute-status.pig
@@ -42,7 +42,7 @@ status_detail =	FOREACH  (GROUP mdata_full BY (monitoring_host,service,hostname,
 	GENERATE  FLATTEN( f_PrepStatus(group.monitoring_host, group.service, group.hostname, group.metric, t.(timestamp,status,summary,message)) );
 };
 
-status_unwrap = FOREACH status_detail GENERATE $0 as mb, $1 as srv, $2 as h, $3 as m, $4 as $n_gg, $5 as $n_eg, $6 as $n_alt, $7 as $n_altf, FLATTEN($8) as ($sd_map);
+status_unwrap = FOREACH status_detail GENERATE $0 as monitoring_box, $1 as service, $2 as host, $3 as metric, FLATTEN($8) as (timestamp,status,summary,message,previous_state,previous_timestamp,date_integer,time_integer);
 describe status_unwrap;
 STORE status_unwrap INTO '$mongo_status_detail' USING com.mongodb.hadoop.pig.MongoInsertStorage();
 


### PR DESCRIPTION
- In this request the UDFs that prepare the data for output (such as GroupEndpointMap and ServiceMap) have been updated
 - Specifically the output tuple of the eval functions has been aligned with the fields expected in the mongodb schema
 - Accordingly the field names have been changed in the ouputSchema function of the udf

- Changes have been reflected also in the pig scripts. Alignment has been establish right before mongo_pig_connector writes the results to the datastore

- Same changes for the status details 

- Since now the fields have standard generic full blown names the mapping functionality (name->abbr) have been dropped from the code and from the configuration files

