### PR TITLE
ARGO-156 Expose report name field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 script: 
  - cd status-computation/java && mvn test
- - cd bin && py.test
+ - cd ./bin && py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 script: 
  - cd status-computation/java && mvn test
- - cd ./bin && py.test
+ - cd ../../bin && py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 script: 
  - cd status-computation/java && mvn test
- - cd ../bin && py.test
+ - cd bin && py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: java
+
+before_install:  
+ - sudo pip install pytest 
+
 script: 
  - cd status-computation/java && mvn test
  - cd ../../bin && py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 
 before_install:  
  - sudo pip install pytest 
-
+ - sudo pip install mock
 script: 
  - cd status-computation/java && mvn test
  - cd ../../bin && py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 language: java
-script: cd status-computation/java && mvn test
+script: 
+ - cd status-computation/java && mvn test
+ - cd ../bin && py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: java
 before_install:  
  - sudo pip install pytest 
  - sudo pip install mock
+ - sudo pip install pymongo
 script: 
  - cd status-computation/java && mvn test
  - cd ../../bin && py.test

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+[![Build Status](https://travis-ci.org/ARGOeu/argo-compute-engine.svg?branch=devel)](https://travis-ci.org/ARGOeu/argo-compute-engine)
+#ARGO COMPUTE ENGINE

--- a/ar-compute.spec
+++ b/ar-compute.spec
@@ -65,7 +65,7 @@ mvn clean
 %attr(0644,root,root) /etc/ar-compute/*.json
 
 %changelog
-* Fri Aug 8 2015 Konstantinos Kagkelidis <kaggis@gmail.com> - 1.6.4-1%{?dist}
+* Fri Aug 7 2015 Konstantinos Kagkelidis <kaggis@gmail.com> - 1.6.4-1%{?dist}
 - ARGO-146 Implement multi-tenancy required changes for the CE
 * Tue Jul 21 2015 Konstantinos Kagkelidis <kaggis@gmail.com> - 1.6.2-7%{?dist}
 - ARGO-190 Recomputation exclude list fix

--- a/ar-compute.spec
+++ b/ar-compute.spec
@@ -1,7 +1,7 @@
 Name: ar-compute
 Summary: A/R Comp Engine core scripts
-Version: 1.6.2
-Release: 7%{?dist}
+Version: 1.6.4
+Release: 1%{?dist}
 License: ASL 2.0
 Buildroot: %{_tmppath}/%{name}-buildroot
 Group:     EGI/SA4
@@ -65,6 +65,8 @@ mvn clean
 %attr(0644,root,root) /etc/ar-compute/*.json
 
 %changelog
+* Fri Aug 8 2015 Konstantinos Kagkelidis <kaggis@gmail.com> - 1.6.4-1%{?dist}
+- ARGO-146 Implement multi-tenancy required changes for the CE
 * Tue Jul 21 2015 Konstantinos Kagkelidis <kaggis@gmail.com> - 1.6.2-7%{?dist}
 - ARGO-190 Recomputation exclude list fix
 * Tue Jun 30 2015 Avraam Tsantekidis <avraamt@grid.auth.gr> - 1.6.2-6%{?dist}

--- a/bin/job_ar.py
+++ b/bin/job_ar.py
@@ -117,7 +117,7 @@ def main(args=None):
 
     # Command to clean a/r data from mongo
     cmd_clean_mongo_ar = [os.path.join(
-        stdl_exec, "mongo_clean_ar.py"), '-d', args.date, '-p', json_cfg["aprofile"]]
+        stdl_exec, "mongo_clean_ar.py"), '-d', args.date, '-r', json_cfg["job"], '-t', args.tenant]
 
     # Command to upload sync data to hdfs
     cmd_upload_sync = [os.path.join(

--- a/bin/mongo_clean_ar.py
+++ b/bin/mongo_clean_ar.py
@@ -58,20 +58,20 @@ def main(args=None):
     log.info("Opening collection: %s", col_service)
     col = db[col_service]
 
-    if args.profile:
-        num_of_rows = col.find({"dt": date_int, "ap": args.profile}).count()
-        log.info("Found %s entries for date %s and profile %s",
-                 num_of_rows, args.date, args.profile)
+    if args.report:
+        num_of_rows = col.find({"date": date_int, "report": args.report}).count()
+        log.info("Found %s entries for date %s and report %s",
+                 num_of_rows, args.date, args.report)
     else:
-        num_of_rows = col.find({"dt": date_int}).count()
+        num_of_rows = col.find({"date": date_int}).count()
         log.info("Found %s entries for date %s", num_of_rows, args.date)
 
     if num_of_rows > 0:
 
-        if args.profile:
+        if args.report:
             log.info(
-                "Remove entries for date: %s and av.profile: %s", args.date, args.profile)
-            col.remove({"dt": date_int, "ap": args.profile})
+                "Remove entries for date: %s and report: %s", args.date, args.report)
+            col.remove({"dt": date_int, "ap": args.report})
         else:
             log.info("Remove entries for date: %s", args.date)
             col.remove({"dt": date_int})
@@ -90,20 +90,20 @@ def main(args=None):
     log.info("Opening collection: %s", col_egroup)
     col = db[col_egroup]
 
-    if args.profile:
-        num_of_rows = col.find({"dt": date_int, "ap": args.profile}).count()
-        log.info("Found %s entries for date %s and profile %s",
-                 num_of_rows, args.date, args.profile)
+    if args.report:
+        num_of_rows = col.find({"date": date_int, "report": args.report}).count()
+        log.info("Found %s entries for date %s and report %s",
+                 num_of_rows, args.date, args.report)
     else:
         num_of_rows = col.find({"dt": date_int}).count()
         log.info("Found %s entries for date %s", num_of_rows, args.date)
 
     if num_of_rows > 0:
 
-        if args.profile:
+        if args.report:
             log.info(
-                "Remove entries for date: %s and av.profile: %s", args.date, args.profile)
-            col.remove({"dt": date_int, "ap": args.profile})
+                "Remove entries for date: %s and report: %s", args.date, args.report)
+            col.remove({"dt": date_int, "ap": args.report})
         else:
             log.info("Remove entries for date: %s", args.date)
             col.remove({"dt": date_int})
@@ -122,7 +122,7 @@ if __name__ == "__main__":
     arg_parser.add_argument(
         "-d", "--date", help="date", dest="date", metavar="DATE", required="TRUE")
     arg_parser.add_argument(
-        "-p", "--profile", help="availability profile", dest="profile", metavar="STRING")
+        "-r", "--report", help="report", dest="report", metavar="STRING")
 
     # Parse the command line arguments accordingly and introduce them to
     # main...

--- a/bin/mongo_clean_ar.py
+++ b/bin/mongo_clean_ar.py
@@ -3,6 +3,7 @@
 # arg parsing related imports
 import os
 import sys
+import utils
 from argolog import init_log
 from argparse import ArgumentParser
 from ConfigParser import SafeConfigParser
@@ -13,35 +14,22 @@ def main(args=None):
 
     # default config
     fn_ar_cfg = "/etc/ar-compute-engine.conf"
-
-    ArConfig = SafeConfigParser()
-    ArConfig.read(fn_ar_cfg)
-
-    # Initialize logging
-    log_mode = ArConfig.get('logging', 'log_mode')
-    log_file = None
-
-    if log_mode == 'file':
-        log_file = ArConfig.get('logging', 'log_file')
-
-    log_level = ArConfig.get('logging', 'log_level')
-    log = init_log(log_mode, log_file, log_level, 'argo.mongo_clean_status')
-
-    mongo_host = ArConfig.get('default', 'mongo_host')
-    mongo_port = ArConfig.get('default', 'mongo_port')
-
-    mongo_service_dest = ArConfig.get('datastore_mapping', 'service_dest')
-    mongo_egroup_dest = ArConfig.get('datastore_mapping', 'egroup_dest')
+    arcomp_conf = "/etc/ar-compute/"
+    # Init configuration
+    cfg = utils.ArgoConfiguration(fn_ar_cfg)
+    cfg.load_tenant_db_conf(os.path.join(arcomp_conf, args.tenant + "_db_conf.json"))
+    # Init logging
+    log = init_log(cfg.log_mode, cfg.log_file, cfg.log_level, 'argo.job_ar')
 
     # Split db.collection path strings to obtain database name and collection
     # name
-    mongo_service_dest = mongo_service_dest.split('.')
-    db_service = mongo_service_dest[0]
-    col_service = mongo_service_dest[1]
 
-    mongo_egroup_dest = mongo_egroup_dest.split('.')
-    db_egroup = mongo_egroup_dest[0]
-    col_egroup = mongo_egroup_dest[1]
+    mongo_host = cfg.get_mongo_host("ar")
+    mongo_port = cfg.get_mongo_port("ar")
+    db_name = cfg.get_mongo_database("ar")
+
+    col_service = "service_ar"
+    col_egroup = "endpoint_group_ar"
 
     # Create a date integer for use in the database queries
     date_int = int(args.date.replace("-", ""))
@@ -52,8 +40,8 @@ def main(args=None):
     # for service collection cleanup do the following
     log.info("Regarding service a/r data...")
 
-    log.info("Opening database: %s", db_service)
-    db = client[db_service]
+    log.info("Opening database: %s", db_name)
+    db = client[db_name]
 
     log.info("Opening collection: %s", col_service)
     col = db[col_service]
@@ -71,10 +59,10 @@ def main(args=None):
         if args.report:
             log.info(
                 "Remove entries for date: %s and report: %s", args.date, args.report)
-            col.remove({"dt": date_int, "ap": args.report})
+            col.delete_many({"date": date_int, "report": args.report})
         else:
             log.info("Remove entries for date: %s", args.date)
-            col.remove({"dt": date_int})
+            col.delete_many({"date": date_int})
 
         log.info("Entries Removed!")
 
@@ -84,8 +72,8 @@ def main(args=None):
     # for service collection cleanup do the following
     log.info("Regarding endpoint group a/r data...")
 
-    log.info("Opening database: %s", db_egroup)
-    db = client[db_egroup]
+    log.info("Opening database: %s", db_name)
+    db = client[db_name]
 
     log.info("Opening collection: %s", col_egroup)
     col = db[col_egroup]
@@ -95,7 +83,7 @@ def main(args=None):
         log.info("Found %s entries for date %s and report %s",
                  num_of_rows, args.date, args.report)
     else:
-        num_of_rows = col.find({"dt": date_int}).count()
+        num_of_rows = col.find({"date": date_int}).count()
         log.info("Found %s entries for date %s", num_of_rows, args.date)
 
     if num_of_rows > 0:
@@ -103,10 +91,10 @@ def main(args=None):
         if args.report:
             log.info(
                 "Remove entries for date: %s and report: %s", args.date, args.report)
-            col.remove({"dt": date_int, "ap": args.report})
+            col.delete_many({"date": date_int, "report": args.report})
         else:
             log.info("Remove entries for date: %s", args.date)
-            col.remove({"dt": date_int})
+            col.delete_many({"date": date_int})
 
         log.info("Entries Removed!")
     else:
@@ -121,6 +109,8 @@ if __name__ == "__main__":
         description="clean status detail data for a day")
     arg_parser.add_argument(
         "-d", "--date", help="date", dest="date", metavar="DATE", required="TRUE")
+    arg_parser.add_argument(
+        "-t", "--tenant", help="tenant owner ", dest="tenant", metavar="STRING", required="TRUE")
     arg_parser.add_argument(
         "-r", "--report", help="report", dest="report", metavar="STRING")
 

--- a/bin/mongo_clean_status.py
+++ b/bin/mongo_clean_status.py
@@ -50,7 +50,7 @@ def main(args=None):
     log.info("Opening collection: %s", col_status)
     col = db[col_status]
 
-    num_of_rows = col.find({"di": date_int}).count()
+    num_of_rows = col.find({"date_integer": date_int}).count()
     log.info("Found %s entries for date %s", num_of_rows, args.date)
 
     if num_of_rows > 0:

--- a/bin/utils.py
+++ b/bin/utils.py
@@ -108,6 +108,15 @@ class ArgoConfiguration(object):
 
         return "".join(mongo_uri)
 
+    def get_mongo_database(self, store):
+        return self.tenant_db_conf[store]["database"]
+
+    def get_mongo_host(self, store):
+        return self.tenant_db_conf[store]["server"]
+
+    def get_mongo_port(self, store):
+        return self.tenant_db_conf[store]["port"]
+
 
 def get_date_under(date):
     """

--- a/bin/utils_test.py
+++ b/bin/utils_test.py
@@ -146,3 +146,9 @@ def test_load_configuration(tmpdir):
     assert cfg.tenant_db_conf == expected_tenant_db_conf
     assert cfg.get_mongo_uri("ar", "endpoint_groups") == mongo_uri_a
     assert cfg.get_mongo_uri("status", "status_metric") == mongo_uri_b
+
+    assert cfg.get_mongo_database("ar") == "argo-egi"
+    assert cfg.get_mongo_database("status") == "argo-egi"
+
+    assert cfg.get_mongo_port("ar") == 27017
+    assert cfg.get_mongo_port("status") == 27017

--- a/bin/utils_test.py
+++ b/bin/utils_test.py
@@ -147,8 +147,8 @@ def test_load_configuration(tmpdir):
     assert cfg.get_mongo_uri("ar", "endpoint_groups") == mongo_uri_a
     assert cfg.get_mongo_uri("status", "status_metric") == mongo_uri_b
 
-    assert cfg.get_mongo_database("ar") == "argo-egi"
-    assert cfg.get_mongo_database("status") == "argo-egi"
+    assert cfg.get_mongo_database("ar") == "argo_EGI"
+    assert cfg.get_mongo_database("status") == "argo_EGI"
 
     assert cfg.get_mongo_port("ar") == 27017
     assert cfg.get_mongo_port("status") == 27017

--- a/status-computation/java/src/main/java/ar/GroupEndpointMap.java
+++ b/status-computation/java/src/main/java/ar/GroupEndpointMap.java
@@ -174,9 +174,10 @@ public class GroupEndpointMap extends EvalFunc<Tuple> {
 		String ggroupName = this.ggMgr.getGroup(ggroupType, egroupName);
 
 		// Add the previous info before adding the tags
-		output.append(dateInt); 				// 0 - date
-		output.append(egroupName); 				// 1 - name
-		output.append(ggroupName); 				// 2 - supergroup 
+		output.append(cfgMgr.report);			// 0 - reportName
+		output.append(dateInt); 				// 1 - date
+		output.append(egroupName); 				// 2 - name
+		output.append(ggroupName); 				// 3 - supergroup 
 		output.append(weightVal); 				// 4 - weight
 
 		// Add the a/r info
@@ -207,6 +208,8 @@ public class GroupEndpointMap extends EvalFunc<Tuple> {
 		Schema groupEndpointData = new Schema();
 
 		// Define first fields
+		Schema.FieldSchema sReport = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "report"),
+				DataType.CHARARRAY);
 		Schema.FieldSchema sDateInt = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "date"),
 				DataType.INTEGER);
 		Schema.FieldSchema sName = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "group"),
@@ -229,6 +232,7 @@ public class GroupEndpointMap extends EvalFunc<Tuple> {
 
 
 		// Add fields to schema
+		groupEndpointData.add(sReport);
 		groupEndpointData.add(sDateInt);
 		groupEndpointData.add(sName);
 		groupEndpointData.add(sSuperGroup);

--- a/status-computation/java/src/main/java/ar/ServiceMap.java
+++ b/status-computation/java/src/main/java/ar/ServiceMap.java
@@ -171,16 +171,17 @@ public class ServiceMap extends EvalFunc<Tuple> {
 		String fullAvProfile = avNamespace + "-" + avProfile;
 		// Add the previous info before adding the tags
 		
-		output.append(dateInt); 			// 0 - date
-		output.append(service); 			// 1 - name
-		output.append(egroupName); 			// 2 - supergroup 
+		output.append(cfgMgr.report);       // 0 - report name
+		output.append(dateInt); 			// 1 - date
+		output.append(service); 			// 2 - name
+		output.append(egroupName); 			// 3 - supergroup 
 
 		// Add the a/r info
-		output.append(av); 					// 3 - availability 
-		output.append(rel); 				// 4 - reliability 
-		output.append(upFraction); 			// 5 - up fraction
-		output.append(downFraction); 		// 6 - down fraction
-		output.append(unknownFraction); 	// 7 - unknown fraction 
+		output.append(av); 					// 4 - availability 
+		output.append(rel); 				// 5 - reliability 
+		output.append(upFraction); 			// 6 - up fraction
+		output.append(downFraction); 		// 7 - down fraction
+		output.append(unknownFraction); 	// 8 - unknown fraction 
 
 		// NOTE: tags will be handled properly in a later PR
 
@@ -203,6 +204,8 @@ public class ServiceMap extends EvalFunc<Tuple> {
 		Schema serviceData = new Schema();
 
 		// Define first fields
+		Schema.FieldSchema sReport = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "report"),
+				DataType.CHARARRAY);
 		Schema.FieldSchema sDateInt = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "date"),
 				DataType.INTEGER);
 		Schema.FieldSchema sName = new Schema.FieldSchema(this.localCfgMgr.getMapped("ar", "name"),
@@ -223,10 +226,10 @@ public class ServiceMap extends EvalFunc<Tuple> {
 		// NOTE: tags and tag schema will be handled properly in a later PR
 
 		// Add fields to schema
-		serviceData.add(sDateInt); // 0 - date
-		serviceData.add(sName); // 
-		serviceData.add(sSuperGroup); // 1 - name
-
+		serviceData.add(sReport);
+		serviceData.add(sDateInt); 
+		serviceData.add(sName); 
+		serviceData.add(sSuperGroup); 
 
 		serviceData.add(sAvailability);
 		serviceData.add(sReliability);

--- a/status-computation/java/src/main/java/ops/ConfigManager.java
+++ b/status-computation/java/src/main/java/ops/ConfigManager.java
@@ -24,7 +24,7 @@ public class ConfigManager {
 	private static final Logger LOG = Logger.getLogger(ConfigManager.class.getName());
 
 	public String tenant;
-	public String job;
+	public String report;
 	public String egroup; // endpoint group
 	public String ggroup; // group of groups
 	public String agroup; // alternative group
@@ -36,7 +36,7 @@ public class ConfigManager {
 
 	public ConfigManager() {
 		this.tenant = null;
-		this.job = null;
+		this.report = null;
 		this.egroup = null;
 		this.ggroup = null;
 		this.weight = null;
@@ -48,7 +48,7 @@ public class ConfigManager {
 
 	public void clear() {
 		this.tenant = null;
-		this.job = null;
+		this.report = null;
 		this.egroup = null;
 		this.ggroup = null;
 		this.weight = null;
@@ -79,7 +79,7 @@ public class ConfigManager {
 			JsonObject jObj = jElement.getAsJsonObject();
 			// Get the simple fields
 			this.tenant = jObj.getAsJsonPrimitive("tenant").getAsString();
-			this.job = jObj.getAsJsonPrimitive("job").getAsString();
+			this.report = jObj.getAsJsonPrimitive("job").getAsString();
 			this.egroup = jObj.getAsJsonPrimitive("egroup").getAsString();
 			this.ggroup = jObj.getAsJsonPrimitive("ggroup").getAsString();
 			this.weight = jObj.getAsJsonPrimitive("weight").getAsString();

--- a/status-computation/java/src/test/java/ops/ConfigManagerTest.java
+++ b/status-computation/java/src/test/java/ops/ConfigManagerTest.java
@@ -31,7 +31,7 @@ public class ConfigManagerTest {
 
 		// Assert that the simple fields are loaded correctly
 		assertEquals("EGI", cfgMgr.tenant);
-		assertEquals("Critical", cfgMgr.job);
+		assertEquals("Critical", cfgMgr.report);
 		assertEquals("SITES", cfgMgr.egroup);
 		assertEquals("NGI", cfgMgr.ggroup);
 		assertEquals("hepspec", cfgMgr.weight);

--- a/status-computation/pig/compute-ar.pig
+++ b/status-computation/pig/compute-ar.pig
@@ -63,8 +63,8 @@ endpoint_groups = FOREACH (GROUP service_flavors BY (groupname)) {
 
 service_ar = FOREACH service_flavors GENERATE FLATTEN(f_ServiceAR(groupname,service,timeline));
 endpoint_groups_ar = FOREACH endpoint_groups GENERATE FLATTEN(f_EndpointGroupAR(groupname,timeline)) as (groupname,availability,reliability,up_f,unknown_f,down_f);
-service_data = FOREACH service_ar GENERATE FLATTEN(f_ServiceDATA(service,groupname,availability,reliability,up_f,unknown_f,down_f)) AS (date,name,supergroup,availability,reliability,up,down,unknown);
-endpoint_groups_data = FOREACH endpoint_groups_ar GENERATE FLATTEN(f_egroupDATA(groupname,availability,reliability,up_f,unknown_f,down_f)) AS (date,name,supergroup,weight,availability,reliability,up,down,uknown); 
+service_data = FOREACH service_ar GENERATE FLATTEN(f_ServiceDATA(service,groupname,availability,reliability,up_f,unknown_f,down_f)) AS (report,date,name,supergroup,availability,reliability,up,down,unknown);
+endpoint_groups_data = FOREACH endpoint_groups_ar GENERATE FLATTEN(f_egroupDATA(groupname,availability,reliability,up_f,unknown_f,down_f)) AS (report,date,name,supergroup,weight,availability,reliability,up,down,uknown); 
 
 STORE service_data INTO '$mongo_service' USING com.mongodb.hadoop.pig.MongoInsertStorage();
 STORE endpoint_groups_data INTO '$mongo_egroup' USING com.mongodb.hadoop.pig.MongoInsertStorage();

--- a/status-computation/pig/compute-ar.pig
+++ b/status-computation/pig/compute-ar.pig
@@ -64,7 +64,7 @@ endpoint_groups = FOREACH (GROUP service_flavors BY (groupname)) {
 service_ar = FOREACH service_flavors GENERATE FLATTEN(f_ServiceAR(groupname,service,timeline));
 endpoint_groups_ar = FOREACH endpoint_groups GENERATE FLATTEN(f_EndpointGroupAR(groupname,timeline)) as (groupname,availability,reliability,up_f,unknown_f,down_f);
 service_data = FOREACH service_ar GENERATE FLATTEN(f_ServiceDATA(service,groupname,availability,reliability,up_f,unknown_f,down_f)) AS (report,date,name,supergroup,availability,reliability,up,down,unknown);
-endpoint_groups_data = FOREACH endpoint_groups_ar GENERATE FLATTEN(f_egroupDATA(groupname,availability,reliability,up_f,unknown_f,down_f)) AS (report,date,name,supergroup,weight,availability,reliability,up,down,uknown); 
+endpoint_groups_data = FOREACH endpoint_groups_ar GENERATE FLATTEN(f_egroupDATA(groupname,availability,reliability,up_f,unknown_f,down_f)) AS (report,date,name,supergroup,weight,availability,reliability,up,down,unknown); 
 
 STORE service_data INTO '$mongo_service' USING com.mongodb.hadoop.pig.MongoInsertStorage();
 STORE endpoint_groups_data INTO '$mongo_egroup' USING com.mongodb.hadoop.pig.MongoInsertStorage();


### PR DESCRIPTION
- In the new multitenant schema report's name as a field plays a critical role in partitioning and indexing the results. 
- The report field is exposed in the udfs that prepare data before outputting to mongo (such as GroupEndpointMap and ServiceMap). 
- Pig scripts are changed accordingly to incorporate the newly exposed field from the udfs
- Python scripts that are used for mongo cleanup are updated to use the new report field

- unit tests added 
