### PR TITLE
Adds missing pyc and pyo files

### DIFF
--- a/ar-compute.spec
+++ b/ar-compute.spec
@@ -54,7 +54,7 @@ mvn clean
 
 %files
 %defattr(0644,root,root)
-%attr(0755,root,root) /usr/libexec/ar-compute/ar-compute.py
+%attr(0755,root,root) /usr/libexec/ar-compute/ar-compute.p*
 %attr(0755,root,root) /usr/libexec/ar-compute/pig/*.pig
 %attr(0755,root,root) /usr/libexec/ar-compute/lib/*
 %attr(0755,root,root) /usr/libexec/ar-compute/bin/*.py


### PR DESCRIPTION
The two offending files were:

- /usr/libexec/ar-compute/ar-compute.pyc
- /usr/libexec/ar-compute/ar-compute.pyo