### PR TITLE
ARGO-211 - Add Endpoint group field output

### DIFF
--- a/status-computation/java/pom.xml
+++ b/status-computation/java/pom.xml
@@ -55,6 +55,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>junit-addons</groupId>
+			<artifactId>junit-addons</artifactId>
+			<version>1.4</version>
+		</dependency>
+		<dependency>
 			<groupId>org.skyscreamer</groupId>
 			<artifactId>jsonassert</artifactId>
 			<version>1.2.3</version>
@@ -87,7 +92,16 @@
 			<artifactId>exp4j</artifactId>
 			<version>0.3.11</version>
 		</dependency>
-
+		<dependency>
+			<groupId>xerces</groupId>
+			<artifactId>xercesImpl</artifactId>
+			<version>2.9.1</version>
+		</dependency>
+		<dependency>
+			<groupId>xalan</groupId>
+			<artifactId>xalan</artifactId>
+			<version>2.7.1</version>
+		</dependency>
 	</dependencies>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/status-computation/java/src/main/java/status/PrepStatusDetails.java
+++ b/status-computation/java/src/main/java/status/PrepStatusDetails.java
@@ -159,7 +159,9 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 		String egroupType = this.cfgMgr.egroup;
 		String egroupName = this.egrpMgr.getGroup(egroupType, hostname, service);
 
+	
 		// add stuff to the output
+		output.append(this.cfgMgr.report); // Add report name
 		output.append(egroupName);
 		output.append(monitoringHost);
 		output.append(service);		   
@@ -173,6 +175,7 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 
 	@Override
 	public Schema outputSchema(Schema input) {
+		Schema.FieldSchema report = new Schema.FieldSchema("report",DataType.CHARARRAY);
 		Schema.FieldSchema endpointGroup = new Schema.FieldSchema("endpoint_group", DataType.CHARARRAY); 
 		Schema.FieldSchema monitoringBox = new Schema.FieldSchema("monitoring_box", DataType.CHARARRAY);
 		Schema.FieldSchema hostname = new Schema.FieldSchema("hostname", DataType.CHARARRAY);
@@ -191,6 +194,7 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 		Schema statusMetric = new Schema();
 		Schema timeline = new Schema();
 
+		statusMetric.add(report);
 		statusMetric.add(endpointGroup);
 		statusMetric.add(monitoringBox);
 		statusMetric.add(serviceType);

--- a/status-computation/java/src/main/java/status/PrepStatusDetails.java
+++ b/status-computation/java/src/main/java/status/PrepStatusDetails.java
@@ -103,7 +103,7 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 			return null;
 
 		// parse input
-		String monitoring_host = (String) input.get(0);
+		String monitoringHost = (String) input.get(0);
 		String service = (String) input.get(1);
 		String hostname = (String) input.get(2);
 		String metric = (String) input.get(3);
@@ -154,10 +154,14 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 				outBag.add(item);
 			}
 		}
+		
+		// Find endpoint group
+		String egroupType = this.cfgMgr.egroup;
+		String egroupName = this.egrpMgr.getGroup(egroupType, hostname, service);
 
 		// add stuff to the output
-
-		output.append(monitoring_host);
+		output.append(egroupName);
+		output.append(monitoringHost);
 		output.append(service);		   
 		output.append(hostname);
 		output.append(metric);
@@ -169,37 +173,38 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 
 	@Override
 	public Schema outputSchema(Schema input) {
-
-		Schema.FieldSchema monitoring_box = new Schema.FieldSchema("monitoring_box", DataType.CHARARRAY);
+		Schema.FieldSchema endpointGroup = new Schema.FieldSchema("endpoint_group", DataType.CHARARRAY); 
+		Schema.FieldSchema monitoringBox = new Schema.FieldSchema("monitoring_box", DataType.CHARARRAY);
 		Schema.FieldSchema hostname = new Schema.FieldSchema("hostname", DataType.CHARARRAY);
-		Schema.FieldSchema service_type = new Schema.FieldSchema("service", DataType.CHARARRAY);
+		Schema.FieldSchema serviceType = new Schema.FieldSchema("service", DataType.CHARARRAY);
 		Schema.FieldSchema metric = new Schema.FieldSchema("metric", DataType.CHARARRAY);
-
+		
 		Schema.FieldSchema timestamp = new Schema.FieldSchema("timestamp", DataType.CHARARRAY);
 		Schema.FieldSchema status = new Schema.FieldSchema("status", DataType.CHARARRAY);
 		Schema.FieldSchema summary = new Schema.FieldSchema("summary", DataType.CHARARRAY);
 		Schema.FieldSchema message = new Schema.FieldSchema("message", DataType.CHARARRAY);
-		Schema.FieldSchema prev_state = new Schema.FieldSchema("previous_state", DataType.CHARARRAY);
-		Schema.FieldSchema prev_ts = new Schema.FieldSchema("previous_timestamp", DataType.CHARARRAY);
-		Schema.FieldSchema date_int = new Schema.FieldSchema("date_integer", DataType.INTEGER);
-		Schema.FieldSchema time_int = new Schema.FieldSchema("time_integer", DataType.INTEGER);
+		Schema.FieldSchema prevState = new Schema.FieldSchema("previous_state", DataType.CHARARRAY);
+		Schema.FieldSchema prevTs = new Schema.FieldSchema("previous_timestamp", DataType.CHARARRAY);
+		Schema.FieldSchema dateInt = new Schema.FieldSchema("date_integer", DataType.INTEGER);
+		Schema.FieldSchema timeInt = new Schema.FieldSchema("time_integer", DataType.INTEGER);
 
-		Schema status_metric = new Schema();
+		Schema statusMetric = new Schema();
 		Schema timeline = new Schema();
 
-		status_metric.add(monitoring_box);
-		status_metric.add(service_type);
-		status_metric.add(hostname);
-		status_metric.add(metric);
+		statusMetric.add(endpointGroup);
+		statusMetric.add(monitoringBox);
+		statusMetric.add(serviceType);
+		statusMetric.add(hostname);
+		statusMetric.add(metric);
 
 		timeline.add(timestamp);
 		timeline.add(status);
 		timeline.add(summary);
 		timeline.add(message);
-		timeline.add(prev_state);
-		timeline.add(prev_ts);
-		timeline.add(date_int);
-		timeline.add(time_int);
+		timeline.add(prevState);
+		timeline.add(prevTs);
+		timeline.add(dateInt);
+		timeline.add(timeInt);
 
 		Schema.FieldSchema timelines = null;
 		try {
@@ -208,10 +213,10 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 			LOG.error(ex);
 		}
 
-		status_metric.add(timelines);
+		statusMetric.add(timelines);
 
 		try {
-			return new Schema(new Schema.FieldSchema("status_metric", status_metric, DataType.TUPLE));
+			return new Schema(new Schema.FieldSchema("status_metric", statusMetric, DataType.TUPLE));
 		} catch (FrontendException ex) {
 			LOG.error(ex);
 		}

--- a/status-computation/java/src/test/java/sync/AvailabilityProfilesTest.java
+++ b/status-computation/java/src/test/java/sync/AvailabilityProfilesTest.java
@@ -15,6 +15,8 @@ import ops.OpsManagerTest;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import junitx.framework.ListAssert;
+
 public class AvailabilityProfilesTest {
 
 	@BeforeClass
@@ -54,7 +56,7 @@ public class AvailabilityProfilesTest {
 		expGroups.add("compute");
 		expGroups.add("storage");
 		// Check the available group list
-		assertEquals("Profile Groups", avp.getProfileGroups("ap1"), expGroups);
+		ListAssert.assertEquals("Profile Groups", avp.getProfileGroups("ap1"), expGroups);
 
 		// Check compute group service list
 		ArrayList<String> expServices = new ArrayList<String>();
@@ -64,18 +66,18 @@ public class AvailabilityProfilesTest {
 		expServices.add("unicore6.TargetSystemFactory");
 		expServices.add("CREAM-CE");
 
-		assertEquals("compute service list", avp.getProfileGroupServices("ap1", "compute"), expServices);
+		ListAssert.assertEquals("compute service list", avp.getProfileGroupServices("ap1", "compute"), expServices);
 
 		// Check storage group service list
 		expServices = new ArrayList<String>();
 		expServices.add("SRM");
 		expServices.add("SRMv2");
-		assertEquals("storage service list", avp.getProfileGroupServices("ap1", "storage"), expServices);
+		ListAssert.assertEquals("storage service list", avp.getProfileGroupServices("ap1", "storage"), expServices);
 
 		// Check storage group service list
 		expServices = new ArrayList<String>();
 		expServices.add("Site-BDII");
-		assertEquals("accounting  list", avp.getProfileGroupServices("ap1", "information"), expServices);
+		ListAssert.assertEquals("accounting  list", avp.getProfileGroupServices("ap1", "information"), expServices);
 
 		// Check Various Service Instances operation
 		assertEquals("group compute: CREAM-CE op", avp.getProfileGroupServiceOp("ap1", "compute", "CREAM-CE"), "OR");

--- a/status-computation/java/src/test/java/sync/MetricProfilesTest.java
+++ b/status-computation/java/src/test/java/sync/MetricProfilesTest.java
@@ -11,6 +11,8 @@ import java.util.ArrayList;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import junitx.framework.ListAssert;
+
 public class MetricProfilesTest {
 
 	@BeforeClass
@@ -45,7 +47,7 @@ public class MetricProfilesTest {
 		serviceList.add("CREAM-CE");
 		serviceList.add("SRMv2");
 
-		assertEquals("Test Presence of Loaded Profile Services", mp.getProfileServices("ch.cern.sam.ROC_CRITICAL"),
+		ListAssert.assertEquals("Test Presence of Loaded Profile Services", mp.getProfileServices("ch.cern.sam.ROC_CRITICAL"),
 				serviceList);
 
 		// Test Loaded Metric Profile service metrics;
@@ -56,7 +58,7 @@ public class MetricProfilesTest {
 		gram5Metrics.add("hr.srce.GRAM-CertLifetime");
 		gram5Metrics.add("hr.srce.GRAM-Command");
 
-		assertEquals("Test GRAM5 metrics", mp.getProfileServiceMetrics("ch.cern.sam.ROC_CRITICAL", "GRAM5"),
+		ListAssert.assertEquals("Test GRAM5 metrics", mp.getProfileServiceMetrics("ch.cern.sam.ROC_CRITICAL", "GRAM5"),
 				gram5Metrics);
 				// Test Loaded Metric Profile service metrics;
 
@@ -65,14 +67,14 @@ public class MetricProfilesTest {
 		qcgMetrics.add("hr.srce.QCG-Computing-CertLifetime");
 		qcgMetrics.add("pl.plgrid.QCG-Computing");
 
-		assertEquals("Test QCG metrics", mp.getProfileServiceMetrics("ch.cern.sam.ROC_CRITICAL", "QCG.Computing"),
+		ListAssert.assertEquals("Test QCG metrics", mp.getProfileServiceMetrics("ch.cern.sam.ROC_CRITICAL", "QCG.Computing"),
 				qcgMetrics);
 
 		// Site-BDII
 		ArrayList<String> siteBdiiMetrics = new ArrayList<String>();
 		siteBdiiMetrics.add("org.bdii.Entries");
 		siteBdiiMetrics.add("org.bdii.Freshness");
-		assertEquals("Test Site-BDII metrics", mp.getProfileServiceMetrics("ch.cern.sam.ROC_CRITICAL", "Site-BDII"),
+		ListAssert.assertEquals("Test Site-BDII metrics", mp.getProfileServiceMetrics("ch.cern.sam.ROC_CRITICAL", "Site-BDII"),
 				siteBdiiMetrics);
 
 		// SRMv2
@@ -85,7 +87,7 @@ public class MetricProfilesTest {
 		srmv2metrics.add("org.sam.SRM-Ls");
 		srmv2metrics.add("org.sam.SRM-LsDir");
 		srmv2metrics.add("org.sam.SRM-Put");
-		assertEquals("SRMv2 ", (mp.getProfileServiceMetrics("ch.cern.sam.ROC_CRITICAL", "SRMv2")), srmv2metrics);
+		ListAssert.assertEquals("SRMv2 ", (mp.getProfileServiceMetrics("ch.cern.sam.ROC_CRITICAL", "SRMv2")), srmv2metrics);
 
 		// Check Existense of Profile Service Metric
 

--- a/status-computation/pig/compute-status.pig
+++ b/status-computation/pig/compute-status.pig
@@ -42,8 +42,8 @@ status_detail =	FOREACH  (GROUP mdata_full BY (monitoring_host,service,hostname,
 	GENERATE  FLATTEN( f_PrepStatus(group.monitoring_host, group.service, group.hostname, group.metric, t.(timestamp,status,summary,message)) );
 };
 
-status_unwrap = FOREACH status_detail GENERATE $0 as monitoring_box, $1 as service, $2 as host, $3 as metric, FLATTEN($4) as (timestamp,status,summary,message,previous_state,previous_timestamp,date_integer,time_integer);
+status_unwrap = FOREACH status_detail GENERATE $0 as report, $1 as endpoint_group, $2 as monitoring_box, $3 as service, $4 as host, $5 as metric, FLATTEN($6) as (timestamp,status,summary,message,previous_state,previous_timestamp,date_integer,time_integer);
 describe status_unwrap;
 STORE status_unwrap INTO '$mongo_status_detail' USING com.mongodb.hadoop.pig.MongoInsertStorage();
 
-
+--- Move here the status aggregation calls


### PR DESCRIPTION
The xml response for status metric results needs to include the endpoint group name. The status metric collection in the datastore doesn't contain an endpoint group name field (has been omitted by mistake). This fix intends to expose the field again in the output of the compute engine. 

- [x] Expose the field in the UDF class
- [x] Expose the field in pig script 
  