### PR TITLE
ARGO-247 Recomputation apiv2 profile changes

### DIFF
--- a/bin/mongo_recompute_test.py
+++ b/bin/mongo_recompute_test.py
@@ -19,9 +19,9 @@ def test_get_collection(mock_client):
 def test_get_results():
     mock_collection = mock.MagicMock()
     mock_collection.find.return_value = ["result1", "result2"]
-    results = mongo_recompute.get_mongo_results(mock_collection, "2015-02-05")
-    query_range = {
-        '$where': "'2015-02-05' >= this.st.split('T')[0] && '2015-02-05' <= this.et.split('T')[0]"}
+    results = mongo_recompute.get_mongo_results(mock_collection, "2015-02-05","critical")
+    query_range = {"report":"critical",
+        '$where': "'2015-02-05' >= this.start_time.split('T')[0] && '2015-02-05' <= this.end_time.split('T')[0]"}
     query_projection = {'_id': 0}
 
     mock_collection.find.assert_called_with(query_range, query_projection)
@@ -29,9 +29,9 @@ def test_get_results():
 
 
 def test_write_output(tmpdir):
-    """ 
+    """
     tmpdir creates a directory unique to this test's invocation
-    and returns a LocalPath object with the ability to write 
+    and returns a LocalPath object with the ability to write
     files with data during tests. tmpdir is used here to write
     temporarily output to a file
     """

--- a/bin/poller_ar.py
+++ b/bin/poller_ar.py
@@ -59,8 +59,8 @@ def get_pending_and_running(col):
     :param col: pymongo collection object
     :return: number of pending requests and running recalculation requests
     """
-    num_pen = col.find({"s": "pending"}).count()
-    num_run = col.find({"s": "running"}).count()
+    num_pen = col.find({"status": "pending"}).count()
+    num_run = col.find({"status": "running"}).count()
     return num_pen, num_run
 
 
@@ -79,8 +79,8 @@ def run_recomputation(col, tenant, num_running, num_pending, threshold):
     elif num_running >= threshold:
         raise ValueError("Over threshold; no recomputation will be executed.")
 
-    pen_recalc = col.find_one({"s": "pending"})
-    pen_recalc_id = str(pen_recalc["_id"])
+    pen_recalc = col.find_one({"status": "pending"})
+    pen_recalc_id = str(pen_recalc["id"])
 
     # Status update allready implemented in recompute
     # Call recompute execution script

--- a/bin/recompute_test.py
+++ b/bin/recompute_test.py
@@ -46,20 +46,17 @@ def test_loop_recompute(mock_do_recompute):
     ar_exec = "/usr/libexec/ar-compute/bin"
     date_range = [datetime(2015, 03, 10), datetime(2015, 03, 11), datetime(2015, 03, 12)]
     tenant = "tenant_FOO"
-    job_set = ["job_a", "job_b"]
-    recompute.loop_recompute(ar_exec, date_range, tenant, job_set, log)
+    job = "job_a"
+    recompute.loop_recompute(ar_exec, date_range, tenant, job, log)
 
     # do_recompute mock method will be called in iteration.
     # prepare a list with all the expected mock calls that
     # the method will recieve
     call_1a = mock.call(ar_exec, "2015-03-10", "tenant_FOO", "job_a", log)
-    call_1b = mock.call(ar_exec, "2015-03-10", "tenant_FOO", "job_b", log)
     call_2a = mock.call(ar_exec, "2015-03-11", "tenant_FOO", "job_a", log)
-    call_2b = mock.call(ar_exec, "2015-03-11", "tenant_FOO", "job_b", log)
     call_3a = mock.call(ar_exec, "2015-03-12", "tenant_FOO", "job_a", log)
-    call_3b = mock.call(ar_exec, "2015-03-12", "tenant_FOO", "job_b", log)
 
-    calls = [call_1a, call_1b, call_2a, call_2b, call_3a, call_3b]
+    calls = [call_1a, call_2a, call_3a]
     # Assert expected call list in one
     mock_do_recompute.assert_has_calls(calls, any_order=True)
 
@@ -86,10 +83,6 @@ def test_get_recomputation():
     mock_collection.find_one.assert_called_with({'id': '551bdd701c8a97e78635a911'})
     assert results == expected_recomputation
 
-    # Assert with invalid ObjectId and raised exception
-    with pytest.raises(ValueError) as excinfo:
-        recompute.get_recomputation(mock_collection, "33", log)
-    assert 'Invalid Object Id used' in str(excinfo.value)
 
 
 def test_get_time_period():
@@ -110,10 +103,6 @@ def test_update_status():
     query_id = {'id': '551bdd701c8a97e78635a911'}
     query_update = {'$set': {'status': 'FOO','timestamp':timestamp}}
 
-    # Assert with a valid Object Id
     mock_collection.update.assert_called_with(query_id, query_update)
 
-    # Assert with invalid ObjectId and raised exception
-    with pytest.raises(ValueError) as excinfo:
-        recompute.get_recomputation(mock_collection, "33", log)
-    assert 'Invalid Object Id used' in str(excinfo.value)
+   

--- a/bin/recompute_test.py
+++ b/bin/recompute_test.py
@@ -8,22 +8,24 @@ from datetime import datetime
 
 FOO_RECOMPUTATION_STR = r"""
 {
-    "es" : [
+    "excluded" : [
         "WCSS"
     ],
-    "et" : "2015-03-15T23:00:00Z",
-    "n" : "NGI_PL",
-    "r" : "2nd recomputation test 3rd key",
-    "s" : "pending",
-    "st" : "2015-03-10T12:00:00Z",
-    "t" : "2015-04-01 14:58:40"
+    "end_time" : "2015-03-15T23:00:00Z",
+    "reason" : "2nd recomputation test 3rd key",
+    "status" : "pending",
+    "start_time" : "2015-03-10T12:00:00Z",
+    "timestamp" : "2015-04-01 14:58:40",
+    "id":"SOME_UUID",
+    "requester_name":"TestName",
+    "requester_email":"starwars@starwars.gr"
 }
 """
 
 
 @mock.patch('recompute.run_cmd')
 def test_do_recompute(mock_run_cmd):
-    
+
     log = logging.getLogger()
 
     ar_exec = "/usr/libexec/ar-compute/bin"
@@ -81,7 +83,7 @@ def test_get_recomputation():
     results = recompute.get_recomputation(mock_collection, "551bdd701c8a97e78635a911", log)
 
     # Assert with a valid Object Id
-    mock_collection.find_one.assert_called_with({'_id': ObjectId('551bdd701c8a97e78635a911')})
+    mock_collection.find_one.assert_called_with({'id': '551bdd701c8a97e78635a911'})
     assert results == expected_recomputation
 
     # Assert with invalid ObjectId and raised exception
@@ -105,8 +107,8 @@ def test_update_status():
     timestamp = datetime.now()
     recompute.update_status(mock_collection, "551bdd701c8a97e78635a911", "FOO", timestamp, log)
 
-    query_id = {'_id': ObjectId('551bdd701c8a97e78635a911')}
-    query_update = {'$set': {'s': 'FOO'}, '$push': {'history': {'status': 'FOO', 'ts': timestamp}}}
+    query_id = {'id': '551bdd701c8a97e78635a911'}
+    query_update = {'$set': {'status': 'FOO','timestamp':timestamp}}
 
     # Assert with a valid Object Id
     mock_collection.update.assert_called_with(query_id, query_update)

--- a/bin/test_poller_ar.py
+++ b/bin/test_poller_ar.py
@@ -18,7 +18,7 @@ def test_run_recomputation(mock_popen):
     pen_recalc.__getitem__.return_value = ObjectId('5559ed3306f6233c190bc851')
     col.find_one.return_value = pen_recalc
     run_recomputation(col, "FOO_tenant", 1, 1, 3)
-    col.find_one.assert_called_with({'s': 'pending'})
+    col.find_one.assert_called_with({'status': 'pending'})
 
     # Assert that the actual sys call is called with the correct arguments
     mock_popen.assert_called_with(
@@ -29,14 +29,14 @@ def test_run_recomputation(mock_popen):
 def test_zero_pending(mock_popen):
     """
     In the case that are zero pending recomputations
-    check that appropriate exception is raised 
+    check that appropriate exception is raised
     """
     pen_recalc, col = MagicMock(), MagicMock()
     pen_recalc.__getitem__.return_value = ObjectId('5559ed3306f6233c190bc851')
     col.find_one.return_value = pen_recalc
     with pytest.raises(ValueError) as excinfo:
         run_recomputation(col, "FOO_tenant", 0, 0, 3)
-        col.find_one.assert_called_with({'s': 'pending'})
+        col.find_one.assert_called_with({'status': 'pending'})
     assert 'Zero pending recomputations' in str(excinfo.value)
 
     # Assert that sys call was not date
@@ -47,14 +47,14 @@ def test_zero_pending(mock_popen):
 def test_over_threshold(mock_popen):
     """
     In the case that number of running > threshold
-    check that appropriate exception is raised 
+    check that appropriate exception is raised
     """
     pen_recalc, col = MagicMock(), MagicMock()
     pen_recalc.__getitem__.return_value = ObjectId('5559ed3306f6233c190bc851')
     col.find_one.return_value = pen_recalc
     with pytest.raises(ValueError) as excinfo:
         run_recomputation(col, "FOO_tenant", 5, 1, 3)
-        col.find_one.assert_called_with({'s': 'pending'})
+        col.find_one.assert_called_with({'status': 'pending'})
     assert 'Over threshold; no recomputation will be executed.' in str(excinfo.value)
 
     # Assert that sys call was not date

--- a/bin/upload_sync.py
+++ b/bin/upload_sync.py
@@ -106,7 +106,7 @@ def main(args=None):
     run_cmd(cmd_call_downtimes, log)
 
     # Call script to retrieve a json file of recomputations for the specific date/tenant from mongodb
-    cmd_mongo_recomputations = [os.path.join(argo_exec,'mongo_recompute.py'),'-d',args.date,'-t',args.tenant]
+    cmd_mongo_recomputations = [os.path.join(argo_exec, 'mongo_recompute.py'), '-d', args.date, '-t', args.tenant, '-j', args.job]
     log.info("Retrieving relevant recomputation requests...")
     run_cmd(cmd_mongo_recomputations, log)
 

--- a/bin/utils.py
+++ b/bin/utils.py
@@ -30,6 +30,8 @@ class ArgoConfiguration(object):
     prefilter_clean = None
     # tenant ar store configuration
     tenant_db_conf = {}
+    # recomputation threshold
+    threshold = None
 
     def __init__(self, filename):
         self.load_config(filename)
@@ -80,6 +82,8 @@ class ArgoConfiguration(object):
         # Grab clean parameters
         self.prefilter_clean = ar_config.get('default', 'prefilter_clean')
         self.sync_clean = ar_config.get('default', 'sync_clean')
+
+        self.threshold = int(ar_config.get('default', 'recomp_threshold'))
 
     def load_tenant_db_conf(self, filename):
         """

--- a/bin/utils_test.py
+++ b/bin/utils_test.py
@@ -11,6 +11,8 @@ mode=local
 prefilter_clean=true
 sync_clean=true
 
+recomp_threshold=1
+
 [logging]    
 log_mode=file
 log_file=/var/log/ar-compute.log
@@ -141,14 +143,14 @@ def test_load_configuration(tmpdir):
 
     assert cfg.mode == "local"
 
-    print cfg.tenant_db_conf
-
     assert cfg.tenant_db_conf == expected_tenant_db_conf
     assert cfg.get_mongo_uri("ar", "endpoint_groups") == mongo_uri_a
     assert cfg.get_mongo_uri("status", "status_metric") == mongo_uri_b
 
     assert cfg.get_mongo_database("ar") == "argo_EGI"
     assert cfg.get_mongo_database("status") == "argo_EGI"
+
+    assert cfg.threshold == 1
 
     assert cfg.get_mongo_port("ar") == 27017
     assert cfg.get_mongo_port("status") == 27017

--- a/status-computation/java/src/main/java/ar/GroupEndpointIntegrate.java
+++ b/status-computation/java/src/main/java/ar/GroupEndpointIntegrate.java
@@ -17,6 +17,7 @@ import org.apache.pig.data.DataType;
 import org.apache.pig.data.DefaultDataBag;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
+import org.apache.pig.impl.logicalLayer.FrontendException;
 import org.apache.pig.impl.logicalLayer.schema.Schema;
 
 import sync.AvailabilityProfiles;
@@ -164,6 +165,13 @@ public class GroupEndpointIntegrate extends EvalFunc<Tuple> {
 		groupEndpointAR.add(unknownFraction);
 		groupEndpointAR.add(downFraction);
 
+		try {
+			return new Schema(new Schema.FieldSchema("endpoint_group_ar", groupEndpointAR, DataType.TUPLE));
+		} catch (FrontendException ex) {
+			LOG.error(ex);
+
+		}
+		
 		return groupEndpointAR;
 
 	}

--- a/status-computation/java/src/main/java/ar/GroupEndpointMap.java
+++ b/status-computation/java/src/main/java/ar/GroupEndpointMap.java
@@ -243,6 +243,13 @@ public class GroupEndpointMap extends EvalFunc<Tuple> {
 		groupEndpointData.add(sUp);
 		groupEndpointData.add(sDown);
 		groupEndpointData.add(sUnknown);
+		
+		try {
+			return new Schema(new Schema.FieldSchema("endpoint_group_data", groupEndpointData, DataType.TUPLE));
+		} catch (FrontendException ex) {
+			LOG.error(ex);
+
+		}
 
 		return groupEndpointData;
 	}

--- a/status-computation/java/src/main/java/ar/GroupEndpointTimelines.java
+++ b/status-computation/java/src/main/java/ar/GroupEndpointTimelines.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import ops.ConfigManager;
 import ops.DAggregator;
@@ -255,20 +256,17 @@ public class GroupEndpointTimelines extends EvalFunc<Tuple> {
 		// Final site aggregate
 		// Get appropriate operation from availability profile
 		totalSite.aggregate(this.apMgr.getTotalOp(aprofile), this.opsMgr);
-
-		// Check for Recalculations
-		String supergroupType = this.cfgMgr.ggroup;
-		String groupType = this.cfgMgr.egroup;
-		String supergroup = this.ggMgr.getGroup(supergroupType, groupname);
-
+	
 		try {
 
-			if (this.recMgr.shouldRecompute(groupname, this.targetDate)) {
+			if (this.recMgr.isExcluded(groupname)) {
 
-				String startRec = this.recMgr.getStart(groupname);
-				String endRec = this.recMgr.getEnd(groupname);
-
-				totalSite.aggregation.fill(this.opsMgr.getDefaultUnknownInt(), startRec, endRec, this.targetDate);
+				ArrayList<Map<String,String>> periods = this.recMgr.getPeriods(groupname,this.targetDate);
+				
+				for (Map<String,String> period : periods){
+					totalSite.aggregation.fill(this.opsMgr.getDefaultUnknownInt(), period.get("start"), period.get("end"), this.targetDate);
+				}
+				
 			}
 
 		} catch (ParseException e) {

--- a/status-computation/java/src/main/java/ar/GroupEndpointTimelines.java
+++ b/status-computation/java/src/main/java/ar/GroupEndpointTimelines.java
@@ -263,10 +263,10 @@ public class GroupEndpointTimelines extends EvalFunc<Tuple> {
 
 		try {
 
-			if (this.recMgr.shouldRecompute(supergroup, groupname, this.targetDate)) {
+			if (this.recMgr.shouldRecompute(groupname, this.targetDate)) {
 
-				String startRec = this.recMgr.getStart(supergroup);
-				String endRec = this.recMgr.getEnd(supergroup);
+				String startRec = this.recMgr.getStart(groupname);
+				String endRec = this.recMgr.getEnd(groupname);
 
 				totalSite.aggregation.fill(this.opsMgr.getDefaultUnknownInt(), startRec, endRec, this.targetDate);
 			}

--- a/status-computation/java/src/main/java/ar/ServiceIntegrate.java
+++ b/status-computation/java/src/main/java/ar/ServiceIntegrate.java
@@ -17,6 +17,7 @@ import org.apache.pig.data.DataType;
 import org.apache.pig.data.DefaultDataBag;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
+import org.apache.pig.impl.logicalLayer.FrontendException;
 import org.apache.pig.impl.logicalLayer.schema.Schema;
 
 import sync.AvailabilityProfiles;
@@ -172,7 +173,16 @@ public class ServiceIntegrate extends EvalFunc<Tuple> {
 		serviceAR.add(unknownFraction);
 		serviceAR.add(downFraction);
 
+		try {
+			return new Schema(new Schema.FieldSchema("service_ar", serviceAR, DataType.TUPLE));
+		} catch (FrontendException ex) {
+			LOG.error(ex);
+
+		}
+		
 		return serviceAR;
+		
+		
 
 	}
 

--- a/status-computation/java/src/main/java/ar/ServiceMap.java
+++ b/status-computation/java/src/main/java/ar/ServiceMap.java
@@ -16,6 +16,7 @@ import org.apache.pig.backend.executionengine.ExecException;
 import org.apache.pig.data.DataType;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
+import org.apache.pig.impl.logicalLayer.FrontendException;
 import org.apache.pig.impl.logicalLayer.schema.Schema;
 
 import sync.AvailabilityProfiles;
@@ -238,6 +239,13 @@ public class ServiceMap extends EvalFunc<Tuple> {
 		serviceData.add(sDown);
 
 
+		try {
+			return new Schema(new Schema.FieldSchema("service_data", serviceData, DataType.TUPLE));
+		} catch (FrontendException ex) {
+			LOG.error(ex);
+
+		}
+		
 		return serviceData;
 
 	}

--- a/status-computation/java/src/test/java/sync/RecomputationsTest.java
+++ b/status-computation/java/src/test/java/sync/RecomputationsTest.java
@@ -31,22 +31,22 @@ public class RecomputationsTest {
 		Recomputations recMgr = new Recomputations();
 		recMgr.loadJson(jsonFile);
 
-		assertEquals(recMgr.shouldRecompute("NGI_GRNET", "GR-01-AUTH", "2013-12-09"), true);
-		assertEquals(recMgr.shouldRecompute("NGI_GRNET", "GR-01-AUTH", "2013-12-10"), true);
-		assertEquals(recMgr.shouldRecompute("NGI_GRNET", "GR-01-AUTH", "2013-12-08"), true);
+		assertEquals(recMgr.shouldRecompute("GR-01-AUTH", "2013-12-09"), true);
+		assertEquals(recMgr.shouldRecompute("GR-01-AUTH", "2013-12-10"), true);
+		assertEquals(recMgr.shouldRecompute("GR-01-AUTH", "2013-12-08"), true);
 		// should return false because date is out of recomputation period
-		assertEquals(recMgr.shouldRecompute("NGI_GRNET", "GR-01-AUTH", "2013-12-07"), false);
-		assertEquals(recMgr.shouldRecompute("NGI_GRNET", "GR-01-AUTH", "2013-12-11"), false);
-		assertEquals(recMgr.shouldRecompute("NGI_GRNET", "GR-01-AUTH", "2013-08-02"), false);
+		assertEquals(recMgr.shouldRecompute("GR-01-AUTH", "2013-12-07"), false);
+		assertEquals(recMgr.shouldRecompute("GR-01-AUTH", "2013-12-11"), false);
+		assertEquals(recMgr.shouldRecompute("GR-01-AUTH", "2013-08-02"), false);
 		// should return false because site is out of exclude list
-		assertEquals(recMgr.shouldRecompute("NGI_GRNET", "GR-04-IASA", "2013-12-09"), false);
-		assertEquals(recMgr.shouldRecompute("NGI_GRNET", "GR-04-IASA", "2013-12-10"), false);
-		assertEquals(recMgr.shouldRecompute("NGI_GRNET", "GR-04-IASA", "2013-12-08"), false);
+		assertEquals(recMgr.shouldRecompute("GR-04-IASA", "2013-12-09"), false);
+		assertEquals(recMgr.shouldRecompute("GR-04-IASA", "2013-12-10"), false);
+		assertEquals(recMgr.shouldRecompute("GR-04-IASA", "2013-12-08"), false);
 		// should return false because NGI doesn't belong in the recomputation
 		// request
-		assertEquals(recMgr.shouldRecompute("NGI_UK", "SITEA", "2013-12-09"), false);
-		assertEquals(recMgr.shouldRecompute("NGI_DE", "SITEB", "2013-12-10"), false);
-		assertEquals(recMgr.shouldRecompute("NGI_FRANCE", "SITEC", "2013-12-08"), false);
+		assertEquals(recMgr.shouldRecompute("SITEA", "2013-12-09"), false);
+		assertEquals(recMgr.shouldRecompute("SITEB", "2013-12-10"), false);
+		assertEquals(recMgr.shouldRecompute("SITEC", "2013-12-08"), false);
 
 	}
 

--- a/status-computation/java/src/test/java/sync/RecomputationsTest.java
+++ b/status-computation/java/src/test/java/sync/RecomputationsTest.java
@@ -8,9 +8,13 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 import ops.OpsManagerTest;
 
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -31,23 +35,51 @@ public class RecomputationsTest {
 		Recomputations recMgr = new Recomputations();
 		recMgr.loadJson(jsonFile);
 
-		assertEquals(recMgr.shouldRecompute("GR-01-AUTH", "2013-12-09"), true);
-		assertEquals(recMgr.shouldRecompute("GR-01-AUTH", "2013-12-10"), true);
-		assertEquals(recMgr.shouldRecompute("GR-01-AUTH", "2013-12-08"), true);
-		// should return false because date is out of recomputation period
-		assertEquals(recMgr.shouldRecompute("GR-01-AUTH", "2013-12-07"), false);
-		assertEquals(recMgr.shouldRecompute("GR-01-AUTH", "2013-12-11"), false);
-		assertEquals(recMgr.shouldRecompute("GR-01-AUTH", "2013-08-02"), false);
-		// should return false because site is out of exclude list
-		assertEquals(recMgr.shouldRecompute("GR-04-IASA", "2013-12-09"), false);
-		assertEquals(recMgr.shouldRecompute("GR-04-IASA", "2013-12-10"), false);
-		assertEquals(recMgr.shouldRecompute("GR-04-IASA", "2013-12-08"), false);
-		// should return false because NGI doesn't belong in the recomputation
-		// request
-		assertEquals(recMgr.shouldRecompute("SITEA", "2013-12-09"), false);
-		assertEquals(recMgr.shouldRecompute("SITEB", "2013-12-10"), false);
-		assertEquals(recMgr.shouldRecompute("SITEC", "2013-12-08"), false);
+		assertEquals(recMgr.isExcluded("GR-01-AUTH"), true);
+		assertEquals(recMgr.isExcluded("HG-03-AUTH"), true);
+		assertEquals(recMgr.isExcluded("GR-04-IASA"), false);
 
+		// Check period functionality
+		ArrayList<Map<String,String>> gr01list = new ArrayList<Map<String,String>>();
+		ArrayList<Map<String,String>> siteAlist = new ArrayList<Map<String,String>>();
+		ArrayList<Map<String,String>> siteBlist = new ArrayList<Map<String,String>>();
+		ArrayList<Map<String,String>> siteClist = new ArrayList<Map<String,String>>();
+		
+		Map<String,String> gr01map = new HashMap<String,String>();
+		
+		Map<String,String> siteA1map = new HashMap<String, String>();
+		Map<String,String> siteA2map = new HashMap<String, String>();
+		
+		
+		Map<String,String> siteBmap = new HashMap<String,String>();
+		Map<String,String> siteCmap = new HashMap<String,String>();
+	
+		// Check period functionality
+		
+		gr01map.put("start", "2013-12-08T12:03:44Z");
+		gr01map.put("end", "2013-12-10T12:03:44Z");
+		
+		siteA1map.put("start", "2013-12-08T12:03:44Z");
+		siteA1map.put("end", "2013-12-08T13:03:44Z");
+		
+		siteA2map.put("start", "2013-12-08T16:03:44Z");
+		siteA2map.put("end", "2013-12-08T18:03:44Z");
+		
+		siteBmap.put("start", "2013-12-08T12:03:44Z");
+		siteBmap.put("end", "2013-12-08T13:03:44Z");
+		
+		siteCmap.put("start", "2013-12-08T16:03:44Z");
+		siteCmap.put("end", "2013-12-08T18:03:44Z");
+		
+		gr01list.add(gr01map);
+	    siteAlist.add(siteA1map);
+	    siteAlist.add(siteA2map);
+	    siteBlist.add(siteBmap);
+	    siteClist.add(siteCmap);
+	    
+	    Assert.assertEquals(recMgr.getPeriods("GR-01-AUTH", "2013-12-08"),gr01list);
+	    Assert.assertEquals(recMgr.getPeriods("SITE-A", "2013-12-08"),siteAlist);
+	    Assert.assertEquals(recMgr.getPeriods("SITE-B", "2013-12-08"),siteBlist);
 	}
 
 }

--- a/status-computation/java/src/test/resources/ops/recomp.json
+++ b/status-computation/java/src/test/resources/ops/recomp.json
@@ -1,12 +1,11 @@
 [{
-	"es" : [
-		"GR-01-AUTH",
-		"HG-03-AUTH"
-	],
-	"et" : "2013-12-10T12:03:44Z",
-	"n" : "NGI_GRNET",
-	"r" : "testing_compute_engine",
-	"s" : "pending",
-	"st" : "2013-12-08T12:03:44Z",
-	"t" : "2014-03-07 12:03:44"
+  "reason": "testing_compute_engine",
+  "start_time": "2013-12-08T12:03:44Z",
+  "end_time": "2013-12-10T12:03:44Z",
+  "exclude": [
+    "GR-01-AUTH",
+    "HG-03-AUTH"
+  ],
+  "status": "running",
+  "timestamp": "2015-02-01 14:58:40"
 }]

--- a/status-computation/java/src/test/resources/ops/recomp.json
+++ b/status-computation/java/src/test/resources/ops/recomp.json
@@ -8,4 +8,26 @@
   ],
   "status": "running",
   "timestamp": "2015-02-01 14:58:40"
+},
+{
+  "reason": "testing_compute_engine",
+  "start_time": "2013-12-08T12:03:44Z",
+  "end_time": "2013-12-08T13:03:44Z",
+  "exclude": [
+    "SITE-A",
+    "SITE-B"
+  ],
+  "status": "running",
+  "timestamp": "2015-02-01 14:58:40"
+},
+{
+  "reason": "testing_compute_engine",
+  "start_time": "2013-12-08T16:03:44Z",
+  "end_time": "2013-12-08T18:03:44Z",
+  "exclude": [
+    "SITE-A",
+    "SITE-c"
+  ],
+  "status": "running",
+  "timestamp": "2015-02-01 14:58:40"
 }]


### PR DESCRIPTION
- Change some udf schema defs for future compatibility with CDH 5.x and pig 12
- Change recomputation handling in CE (remove use of supergroups)
- Change python scripts
 - retrieve recomputation by uuid (instead of object _id)
 - use report names when executing recomputations

