### PR TITLE
ARGO-245 Reference results using report.id instead of report.name

### DIFF
--- a/status-computation/java/src/main/java/ar/GroupEndpointMap.java
+++ b/status-computation/java/src/main/java/ar/GroupEndpointMap.java
@@ -174,7 +174,7 @@ public class GroupEndpointMap extends EvalFunc<Tuple> {
 		String ggroupName = this.ggMgr.getGroup(ggroupType, egroupName);
 
 		// Add the previous info before adding the tags
-		output.append(cfgMgr.report);			// 0 - reportName
+		output.append(cfgMgr.id);				// 0 - report id
 		output.append(dateInt); 				// 1 - date
 		output.append(egroupName); 				// 2 - name
 		output.append(ggroupName); 				// 3 - supergroup 

--- a/status-computation/java/src/main/java/ar/ServiceMap.java
+++ b/status-computation/java/src/main/java/ar/ServiceMap.java
@@ -172,7 +172,7 @@ public class ServiceMap extends EvalFunc<Tuple> {
 		String fullAvProfile = avNamespace + "-" + avProfile;
 		// Add the previous info before adding the tags
 		
-		output.append(cfgMgr.report);       // 0 - report name
+		output.append(cfgMgr.id);       // 0 - report id
 		output.append(dateInt); 			// 1 - date
 		output.append(service); 			// 2 - name
 		output.append(egroupName); 			// 3 - supergroup 

--- a/status-computation/java/src/main/java/ops/ConfigManager.java
+++ b/status-computation/java/src/main/java/ops/ConfigManager.java
@@ -23,6 +23,7 @@ public class ConfigManager {
 
 	private static final Logger LOG = Logger.getLogger(ConfigManager.class.getName());
 
+	public String id; // report uuid reference
 	public String tenant;
 	public String report;
 	public String egroup; // endpoint group
@@ -37,6 +38,7 @@ public class ConfigManager {
 	public ConfigManager() {
 		this.tenant = null;
 		this.report = null;
+		this.id = null;
 		this.egroup = null;
 		this.ggroup = null;
 		this.weight = null;
@@ -47,6 +49,7 @@ public class ConfigManager {
 	}
 
 	public void clear() {
+		this.id=null;
 		this.tenant = null;
 		this.report = null;
 		this.egroup = null;
@@ -78,6 +81,7 @@ public class ConfigManager {
 			JsonElement jElement = jsonParser.parse(br);
 			JsonObject jObj = jElement.getAsJsonObject();
 			// Get the simple fields
+			this.id = jObj.getAsJsonPrimitive("id").getAsString();
 			this.tenant = jObj.getAsJsonPrimitive("tenant").getAsString();
 			this.report = jObj.getAsJsonPrimitive("job").getAsString();
 			this.egroup = jObj.getAsJsonPrimitive("egroup").getAsString();

--- a/status-computation/java/src/main/java/status/PrepStatusDetails.java
+++ b/status-computation/java/src/main/java/status/PrepStatusDetails.java
@@ -161,7 +161,7 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 
 	
 		// add stuff to the output
-		output.append(this.cfgMgr.report); // Add report name
+		output.append(this.cfgMgr.id); // Add report id
 		output.append(egroupName);
 		output.append(monitoringHost);
 		output.append(service);		   

--- a/status-computation/java/src/test/java/ops/ConfigManagerTest.java
+++ b/status-computation/java/src/test/java/ops/ConfigManagerTest.java
@@ -35,6 +35,7 @@ public class ConfigManagerTest {
 		assertEquals("SITES", cfgMgr.egroup);
 		assertEquals("NGI", cfgMgr.ggroup);
 		assertEquals("hepspec", cfgMgr.weight);
+		assertEquals("c800846f-8478-4af8-85d1-a3f12fe4c18f",cfgMgr.id);
 
 		// Assert compound fields
 		assertEquals("Production", cfgMgr.ggroupTags.get("infrastructure"));

--- a/status-computation/java/src/test/resources/ops/config.json~
+++ b/status-computation/java/src/test/resources/ops/config.json~
@@ -1,6 +1,5 @@
 {
   "tenant":"EGI",
-  "id":"c800846f-8478-4af8-85d1-a3f12fe4c18f",
   "job":"Critical",
   "egroup":"SITES",
   "ggroup":"NGI",


### PR DESCRIPTION
Each defined report in the Compute Engine is used to produce a different set of results. The results while produced and stored in datastore are tagged with the according report name for future reference.

In this PR, the Compute Engine uses the report's id (uuid) as a future reference and tags the results. This gives the flexibility to be able to update/edit report.name field without affecting the relationship with the already computed results

- Report information is loaded through configuration in the ConfigManager Class. Class has been updated to hold a new field `id` regarding report.id. Also the json Load function has been updated to look for an `id` field in json configuration.
- Java UDFS regarding a/r and status results have been updated to use ConfigManager.id field as a report reference
- Unit tests and resource files have been updated accordingly