### PR TITLE
ARGO-245 Update Spec requirement for java-1.7.0-openjdk

### DIFF
--- a/ar-compute.spec
+++ b/ar-compute.spec
@@ -1,7 +1,7 @@
 Name: ar-compute
 Summary: A/R Comp Engine core scripts
 Version: 1.6.5
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: ASL 2.0
 Buildroot: %{_tmppath}/%{name}-buildroot
 Group:     EGI/SA4
@@ -14,7 +14,7 @@ Requires: hbase
 Requires: hcatalog
 Requires: pig
 Requires: pig-udf-datafu
-Requires: java-1.6.0-openjdk
+Requires: java-1.7.0-openjdk
 
 %description
 Installs the core A/R Compute Engine
@@ -65,6 +65,8 @@ mvn clean
 %attr(0644,root,root) /etc/ar-compute/*.json
 
 %changelog
+* Tue Nov 3 2015 Konstantinos Kagkelidis <kaggis@gmail.com> - 1.6.5-2%{?dist}
+- ARGO-245 Upgrade devel to CDH 5.x - Update spec requirement to java-1.7.0-openjdk
 * Thu Oct 29 2015 Konstantinos Kagkelidis <kaggis@gmail.com> - 1.6.5-1%{?dist}
 - ARGO-207 minor bug fix related to how mongo_clean_status is called from within job_status_detail python wrapper
 - ARGO-211 Use ListArray assertions instead of plain asserts when dealing with arraylists.


### PR DESCRIPTION
After upgrading cluster to CDH 5.x, java 1.7 is required. 

Change spec file requirement to openjdk-1.7.0
