### PR TITLE
ARGO-245 Update Spec remove hcatalog requirement

### DIFF
--- a/ar-compute.spec
+++ b/ar-compute.spec
@@ -11,7 +11,6 @@ Requires: python-argparse
 Requires: python-pymongo
 Requires: hive
 Requires: hbase
-Requires: hcatalog
 Requires: pig
 Requires: pig-udf-datafu
 Requires: java-1.7.0-openjdk


### PR DESCRIPTION
Remove hcatalog requirement (After Upgrading cluster to CDH 5.x)
