### PR TITLE
ARGO-285 Use report uuid when cleaning data

### DIFF
--- a/bin/job_ar.py
+++ b/bin/job_ar.py
@@ -117,7 +117,7 @@ def main(args=None):
 
     # Command to clean a/r data from mongo
     cmd_clean_mongo_ar = [os.path.join(
-        stdl_exec, "mongo_clean_ar.py"), '-d', args.date, '-r', json_cfg["job"], '-t', args.tenant]
+        stdl_exec, "mongo_clean_ar.py"), '-d', args.date, '-r', json_cfg["id"], '-t', args.tenant]
 
     # Command to upload sync data to hdfs
     cmd_upload_sync = [os.path.join(

--- a/bin/job_status_detail.py
+++ b/bin/job_status_detail.py
@@ -109,7 +109,7 @@ def main(args=None):
 
     # Command to clean a/r data from mongo
     cmd_clean_mongo_status = [
-        os.path.join(stdl_exec, "mongo_clean_status.py"), '-d', args.date, '-t', args.tenant, '-r', json_cfg['job']]
+        os.path.join(stdl_exec, "mongo_clean_status.py"), '-d', args.date, '-t', args.tenant, '-r', json_cfg['id']]
 
     # Command to upload sync data to hdfs
     cmd_upload_sync = [os.path.join(

--- a/doc/cli-interaction.md
+++ b/doc/cli-interaction.md
@@ -63,13 +63,13 @@ This utility is used in order to delete availability and reliability data from t
 
 - `-d --date {YYYY-MM-DD}` the date (day) for which to delete the availability and reliability data (Required)
 - `-t --tenant {STRING}` the name of the tenant. Case sensitive. (Required)
-- `-r --report {STRING}` the name of the report that results belong to. Case sensitive (Required)
+- `-r --report {STRING}` the id (uuid format) of the report that results belong to. Case sensitive (Required)
 
 <a id="status"></a>
 
 ### mongo_clean_status.py
 
-This utility can be used in order to delete the status detail data from the datastore, for a specified tenant,report and date. 
+This utility can be used in order to delete the status detail data from the datastore, for a specified tenant,report and date.
 
 #### Full path
 ```
@@ -79,4 +79,4 @@ This utility can be used in order to delete the status detail data from the data
 
 - `-d --date {YYYY-MM-DD}` the date for which to delete the status detail data from the datastore (Required)
 - `-t --tenant {STRING}` the name of the tenant. Case sensitive. (Required)
-- `-r --report {STRING}` the name of the report that results belong to. Case sensitive (Required)
+- `-r --report {STRING}` the id (uuid format) of the  report that results belong to. Case sensitive (Required)


### PR DESCRIPTION
# Description
Mongo clean data scripts still target results using report name. Should use report id

# Implementation
Use report id when calling clean scripts mongo_clean_ar.py , mongo_clean_status.py 

