### PR TITLE
Adds support for cobertura coverage reports

### DIFF
--- a/status-computation/java/pom.xml
+++ b/status-computation/java/pom.xml
@@ -20,6 +20,24 @@
 					<target>1.6</target>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>cobertura-maven-plugin</artifactId>
+				<version>2.7</version>
+				<configuration>
+					<formats>
+						<format>xml</format>
+					</formats>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>cobertura</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 	<dependencies>


### PR DESCRIPTION
Currently we are generating only surefire reports. This pull requests adds the cobertura-magen-plugin in order to be able to generate cobertura coverage reports.