### PR TITLE
ARGO-316 - Target python 2.6 and add coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,20 @@
-language: java
+# Set-up a python centric enviroment in order to easily choose py version:2.6
+# bonus: Java 7 and mvn also included
+language: python
+# Target py version 2.6
+python:
+  - "2.6"
 
-before_install:  
- - sudo pip install pytest 
- - sudo pip install mock
- - sudo pip install pymongo
-script: 
+install:
+ - pip install pymongo
+ - pip install coverage
+
+script:
+# Gather coverage data on python src
+ - coverage run --source=./bin/ -m py.test
+# Generate coverage.xml report
+ - coverage xml
+# Run python unittests again and generate junit style xml report
+ - py.test ./bin/ --junitxml=./bin/junit.xml
+# Run unittests and generate reports on java src
  - cd status-computation/java && mvn test
- - cd ../../bin && py.test


### PR DESCRIPTION
## Issue
travis enviroment doesn't target python 2.6 -- instead uses python 2.7 as a default. 

## Fix 
In order to target easily python 2.6 change travis environment from java to python-centric. This environment still comes with java 7 and mvn installed. 
Use coverage.py for coverage in python src 
