### PR TITLE
ARGO-326 Skips tests when packaging

### DIFF
--- a/ar-compute.spec
+++ b/ar-compute.spec
@@ -21,7 +21,7 @@ Installs the core A/R Compute Engine
 %prep
 %setup 
 cd status-computation/java
-mvn package
+mvn package -Dmaven.test.skip
 
 %install 
 %{__rm} -rf %{buildroot}


### PR DESCRIPTION
By default ```mvn package``` executes all the unit tests before
packaging. This commit changes this behaviour in order not to
run the unit tests