### PR TITLE
ARGO-327 attach list of endpoint groups for each endpoint

### DIFF
--- a/status-computation/java/src/main/java/ar/PickEndpoints.java
+++ b/status-computation/java/src/main/java/ar/PickEndpoints.java
@@ -157,11 +157,13 @@ public class PickEndpoints extends FilterFunc {
 			return false;
 
 		// Filter By endpoint group if belongs to supergroup
-		String groupname = egMgr.getGroup(this.cfgMgr.egroup, hostname, service);
-		if (ggMgr.checkSubGroup(groupname) == false)
-			return false;
+		ArrayList<String> groupnames = egMgr.getGroup(this.cfgMgr.egroup, hostname, service);
+		for (String groupname : groupnames){
+			if (ggMgr.checkSubGroup(groupname) == true)
+				return true;
+		}
 
-		return true;
+		return false;
 
 	}
 

--- a/status-computation/java/src/main/java/status/PrepStatusDetails.java
+++ b/status-computation/java/src/main/java/status/PrepStatusDetails.java
@@ -14,6 +14,7 @@ import org.apache.log4j.Logger;
 import ops.ConfigManager;
 
 import org.apache.pig.EvalFunc;
+import org.apache.pig.data.BagFactory;
 import org.apache.pig.data.DataBag;
 import org.apache.pig.data.DataType;
 import org.apache.pig.data.Tuple;
@@ -44,7 +45,8 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 	public ConfigManager cfgMgr;
 
 	private TupleFactory tupFactory;
-
+	private BagFactory bagFactory;
+	
 	private boolean initialized;
 
 	private static final Logger LOG = Logger.getLogger(PrepStatusDetails.class.getName());
@@ -63,7 +65,8 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 		this.cfgMgr = new ConfigManager();
 
 		this.tupFactory = TupleFactory.getInstance();
-
+		this.bagFactory = BagFactory.getInstance();
+		
 		this.initialized = false;
 
 	}
@@ -157,12 +160,21 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 		
 		// Find endpoint group
 		String egroupType = this.cfgMgr.egroup;
-		String egroupName = this.egrpMgr.getGroup(egroupType, hostname, service);
-
+		ArrayList<String> groups = egrpMgr.getGroup(egroupType, hostname, service);
+		// Create output Tuple
+		DataBag groupBag = this.bagFactory.newDefaultBag();
+		
+		for (String group : groups)
+		{
+			Tuple cur_tupl = tupFactory.newTuple();
+			cur_tupl.append(group);
+			groupBag.add(cur_tupl);
+		}
+		
 	
 		// add stuff to the output
 		output.append(this.cfgMgr.id); // Add report id
-		output.append(egroupName);
+		output.append(groupBag);
 		output.append(monitoringHost);
 		output.append(service);		   
 		output.append(hostname);
@@ -191,11 +203,21 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 		Schema.FieldSchema dateInt = new Schema.FieldSchema("date_integer", DataType.INTEGER);
 		Schema.FieldSchema timeInt = new Schema.FieldSchema("time_integer", DataType.INTEGER);
 
+		Schema.FieldSchema groupName = new Schema.FieldSchema("group_name", DataType.CHARARRAY);
+		
 		Schema statusMetric = new Schema();
 		Schema timeline = new Schema();
 
 		statusMetric.add(report);
-		statusMetric.add(endpointGroup);
+		
+		Schema.FieldSchema groups = null;
+		try {
+			groups = new Schema.FieldSchema("groups", timeline, DataType.BAG);
+		} catch (FrontendException ex) {
+			LOG.error(ex);
+		}
+		
+		statusMetric.add(groups);
 		statusMetric.add(monitoringBox);
 		statusMetric.add(serviceType);
 		statusMetric.add(hostname);

--- a/status-computation/java/src/main/java/sync/EndpointGroups.java
+++ b/status-computation/java/src/main/java/sync/EndpointGroups.java
@@ -77,15 +77,17 @@ public class EndpointGroups {
 		return false;
 	}
 
-	public String getGroup(String type, String hostname, String service) {
-
+	public ArrayList<String> getGroup(String type, String hostname, String service) {
+		
+		ArrayList<String> results = new ArrayList<String>();
+		
 		for (EndpointItem item : fList) {
 			if (item.type.equals(type) && item.hostname.equals(hostname) && item.service.equals(service)) {
-				return item.group;
+				results.add(item.group);
 			}
 		}
 
-		return null;
+		return results;
 	}
 
 	public HashMap<String, String> getGroupTags(String type, String hostname, String service) {

--- a/status-computation/java/src/test/java/sync/EndpointGroupsTest.java
+++ b/status-computation/java/src/test/java/sync/EndpointGroupsTest.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.ArrayList;
 
 import ops.ConfigManager;
 
@@ -39,7 +40,9 @@ public class EndpointGroupsTest {
 		assertTrue(ge.checkEndpoint("se.grid.tuke.sk", "SRMv2"));
 		assertTrue(ge.checkEndpoint("dpm.grid.atomki.hu", "SRMv2"));
 		// Test check Group retrieval
-		assertEquals(ge.getGroup("SITES", "gt3.pnpi.nw.ru", "CREAM-CE"), "ru-PNPI");
+		ArrayList<String> result1 = new ArrayList<String>();
+		result1.add("ru-PNPI");
+		assertEquals(ge.getGroup("SITES", "gt3.pnpi.nw.ru", "CREAM-CE"), result1);
 
 		// Test Tag Filtering (Wont filter out anything since input is already
 		// filtered)

--- a/status-computation/pig/compute-ar.pig
+++ b/status-computation/pig/compute-ar.pig
@@ -24,7 +24,7 @@ DEFINE f_ServiceAR ar.ServiceIntegrate('$ops', '$aps', '$mode');
 DEFINE f_egroupDATA ar.GroupEndpointMap('$cfg', '$aps', '$weight', '$ggs', '$egs', '$dt', '$mode', '$localCfg');
 DEFINE f_ServiceDATA ar.ServiceMap('$cfg', '$aps', '$ggs', '$egs', '$dt', '$mode', '$localCfg');
 
---- Get One Day Before metric data in ordet to get past status references 
+--- Get One Day Before metric data in ordet to get past status references
 p_mdata = LOAD '$p_mdata' using org.apache.pig.piggybank.storage.avro.AvroStorage();
 p_mdata_trim = FOREACH p_mdata GENERATE  service, hostname, metric, timestamp, status;
 p_mdata_clean = FILTER p_mdata_trim BY f_PickEndpoints(hostname,service,metric);
@@ -37,12 +37,12 @@ p_ref = FOREACH (GROUP p_mdata_clean BY (service,hostname,metric)) {
 };
 
 
---- Get Target Day metric data 
+--- Get Target Day metric data
 mdata= LOAD '$mdata' using org.apache.pig.piggybank.storage.avro.AvroStorage();
 mdata_trim = FOREACH mdata GENERATE  service, hostname, metric, timestamp, status;
 mdata_clean = FILTER mdata_trim BY f_PickEndpoints(hostname,service,metric);
 
---- Union previous mdata with current 
+--- Union previous mdata with current
 mdata_full = UNION mdata_clean,p_ref;
 
 
@@ -51,10 +51,12 @@ endpoints =	FOREACH  (GROUP mdata_full BY (service,hostname)) {
 };
 
 -- Add Group info (SITES)
-endpoints_info = FOREACH endpoints GENERATE FLATTEN(f_AddGroupInfo(service,hostname,timeline)) as (service,hostname,timeline,groupname);
+endpoints_info = FOREACH endpoints GENERATE FLATTEN(f_AddGroupInfo(service,hostname,timeline)) as (service,hostname,timeline,grouplist);
 
-service_flavors = FOREACH (GROUP endpoints_info BY (groupname,service)) {
-	GENERATE FLATTEN(f_ServiceTl(group.groupname, group.service , endpoints_info.(hostname,timeline))) as (groupname, service, timeline);
+endpoints_info_final = FOREACH endpoints_info GENERATE service,hostname,timeline,FLATTEN(grouplist) as groupname;
+
+service_flavors = FOREACH (GROUP endpoints_info_final BY (groupname,service)) {
+	GENERATE FLATTEN(f_ServiceTl(group.groupname, group.service , endpoints_info_final.(hostname,timeline))) as (groupname, service, timeline);
 }
 
 endpoint_groups = FOREACH (GROUP service_flavors BY (groupname)) {
@@ -64,7 +66,7 @@ endpoint_groups = FOREACH (GROUP service_flavors BY (groupname)) {
 service_ar = FOREACH service_flavors GENERATE FLATTEN(f_ServiceAR(groupname,service,timeline));
 endpoint_groups_ar = FOREACH endpoint_groups GENERATE FLATTEN(f_EndpointGroupAR(groupname,timeline)) as (groupname,availability,reliability,up_f,unknown_f,down_f);
 service_data = FOREACH service_ar GENERATE FLATTEN(f_ServiceDATA(service,groupname,availability,reliability,up_f,unknown_f,down_f)) AS (report,date,name,supergroup,availability,reliability,up,down,unknown);
-endpoint_groups_data = FOREACH endpoint_groups_ar GENERATE FLATTEN(f_egroupDATA(groupname,availability,reliability,up_f,unknown_f,down_f)) AS (report,date,name,supergroup,weight,availability,reliability,up,down,unknown); 
+endpoint_groups_data = FOREACH endpoint_groups_ar GENERATE FLATTEN(f_egroupDATA(groupname,availability,reliability,up_f,unknown_f,down_f)) AS (report,date,name,supergroup,weight,availability,reliability,up,down,unknown);
 
 STORE service_data INTO '$mongo_service' USING com.mongodb.hadoop.pig.MongoInsertStorage();
 STORE endpoint_groups_data INTO '$mongo_egroup' USING com.mongodb.hadoop.pig.MongoInsertStorage();


### PR DESCRIPTION
## Goal

Compute engine should be able to handle a service endpoint that belongs -at the same time- to multiple endpoint groups.

## Implementation

This feature requires refactoring in java udf classes and in pig scripts. Till now metric data rows were enriched with an endpoint_group field (retrieved by asking endpoint group topology mgr class based on hostname and service fields). The assumption was that each metric data row having a hostname and service info (service endpoint) corresponds to a unique endpoint group. Now the endpoint group mgr returns a list of endpoint groups that contain the endpoint. Then by having a crossproduct (X) of relevant metric data rows and endpoint group list, the needed (multiplied) metric data is produced
 