### PR TITLE
ARGO-332 Optimize single timelines

### DIFF
--- a/status-computation/java/src/main/java/ops/CTimeline.java
+++ b/status-computation/java/src/main/java/ops/CTimeline.java
@@ -134,6 +134,8 @@ public class CTimeline {
 	public void aggregate(CTimeline second, OpsManager opsMgr, int op){
 		if (this.isEmpty()){
 			this.bulkInsert(second.getSamples());
+			// Optimize even when we have a single timeline for aggregation
+			this.optimize(); 
 			return;
 		}
 		

--- a/status-computation/java/src/test/java/ops/CAggregatorTest.java
+++ b/status-computation/java/src/test/java/ops/CAggregatorTest.java
@@ -58,5 +58,34 @@ public class CAggregatorTest {
         
 	}
 	
+	@Test
+	public void testSingleAggregation() throws ParseException, IOException, URISyntaxException  {
+		
+		// Prepare Resource File
+		URL resJsonFile = CAggregatorTest.class.getResource("/ops/EGI-algorithm.json");
+		File JsonFile = new File(resJsonFile.toURI());
+		// Instantiate class
+		OpsManager opsMgr = new OpsManager();
+		// Test loading file
+		opsMgr.loadJson(JsonFile);
+		
+        CAggregator agg = new CAggregator();
+         
+        agg.insert("hostFoo.lan","2015-05-01T00:00:00Z",opsMgr.getIntStatus("OK"));
+        agg.insert("hostFoo.lan","2015-05-01T09:00:00Z",opsMgr.getIntStatus("OK"));
+        agg.insert("hostFoo.lan","2015-05-01T12:00:00Z",opsMgr.getIntStatus("OK"));
+        agg.insert("hostFoo.lan","2015-05-01T22:00:00Z",opsMgr.getIntStatus("OK"));
+        
+     
+	
+        agg.aggregate(opsMgr, "AND");
+        
+        CTimeline expected = new CTimeline("2015-05-01T00:00:00Z");
+        expected.insert("2015-05-01T00:00:00Z",opsMgr.getIntStatus("OK"));
+    
+        assertEquals(expected.getSamples(),agg.getSamples());
+        
+	}
+	
 	
 }


### PR DESCRIPTION
### Normal operation
When going from lower levels of timelines to upper ones, we aggregate. (metrics -> endpoints -> services -> endpoint_groups -> upper groups etc...)


### Issue 
If during an aggregation, the candidate list contains only ONE timeline, then CE skips aggregation and passes the timeline to the upper level.
The problem is that optimization procedure call, happens only after an aggregation,  thus resulting in some cases in unoptimized timelines. Especially when: a site has a single service with a single endpoint containing only a single metric.


### Point of focus
Java class that implements Continuous Timeline and Aggregion (`ops.CTimeline`)


### Solution
- When aggregation call is skipped, due to single timeline presence, add call to optimize it
- Update relevant unittests
