### PR TITLE
ARGO-337 Handle metric data from multiple monitoring engines

### DIFF
--- a/bin/job_status_detail.py
+++ b/bin/job_status_detail.py
@@ -80,6 +80,7 @@ def main(args=None):
     pig_params['mps'] = sync_path + 'poem_sync.avro'
     pig_params['cfg'] = cfg_path + args.tenant + '_' + args.job + '_cfg.json'
     pig_params['aps'] = cfg_path + args.tenant + '_' + args.job + '_ap.json'
+    pig_params['rec'] = cfg_path + 'recomputations_' + args.tenant + '_' + date_under + '.json'
     pig_params['ops'] = cfg_path + args.tenant + '_ops.json'
     pig_params['dt'] = args.date
     pig_params['mode'] = mode

--- a/status-computation/java/src/main/java/ar/GroupEndpointTimelines.java
+++ b/status-computation/java/src/main/java/ar/GroupEndpointTimelines.java
@@ -94,7 +94,7 @@ public class GroupEndpointTimelines extends EvalFunc<Tuple> {
 
 	}
 
-	public void init() throws IOException {
+	public void init() throws IOException, ParseException {
 		if (this.fsUsed.equalsIgnoreCase("cache")) {
 			this.opsMgr.loadJson(new File("./ops"));
 			this.apMgr.loadJson(new File("./aps"));
@@ -133,6 +133,10 @@ public class GroupEndpointTimelines extends EvalFunc<Tuple> {
 				this.init(); // If not open them
 			} catch (IOException e) {
 				LOG.error("Could not initialize sync structures");
+				LOG.error(e);
+				throw new IllegalStateException();
+			} catch (ParseException e) {
+				LOG.error("Could not initialize sync structures due to Parse Date Error");
 				LOG.error(e);
 				throw new IllegalStateException();
 			}

--- a/status-computation/java/src/main/java/ar/PickEndpoints.java
+++ b/status-computation/java/src/main/java/ar/PickEndpoints.java
@@ -2,6 +2,7 @@ package ar;
 
 import java.io.File;
 import java.io.IOException;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,6 +17,7 @@ import sync.AvailabilityProfiles;
 import sync.EndpointGroups;
 import sync.GroupsOfGroups;
 import sync.MetricProfiles;
+import sync.Recomputations;
 
 public class PickEndpoints extends FilterFunc {
 
@@ -24,6 +26,7 @@ public class PickEndpoints extends FilterFunc {
 	public GroupsOfGroups ggMgr;
 	public MetricProfiles mpsMgr;
 	public AvailabilityProfiles apsMgr;
+	public Recomputations recMgr;
 
 	public ConfigManager cfgMgr;
 
@@ -32,21 +35,24 @@ public class PickEndpoints extends FilterFunc {
 	private String fnGgrp;
 	private String fnCfg;
 	private String fnAps;
+	private String fnRec;
 	private int filter;
 
 	private String fsUsed; // local,hdfs,cache (distrubuted_cache)
 
 	private boolean initialized = false;
 
-	public PickEndpoints(String fnEgrp, String fnMps, String fnAps, String fnGgrp, String fnCfg, String filter,
+	public PickEndpoints(String fnRec, String fnEgrp, String fnMps, String fnAps, String fnGgrp, String fnCfg, String filter,
 			String fsUsed) throws IOException {
 		// set first the filenames
+		this.fnRec = fnRec;
 		this.fnEgrp = fnEgrp;
 		this.fnMps = fnMps;
 		this.fnGgrp = fnGgrp;
 		this.fnCfg = fnCfg;
 		this.fnAps = fnAps;
 		// set the Structures
+		this.recMgr = new Recomputations();
 		this.egMgr = new EndpointGroups();
 		this.ggMgr = new GroupsOfGroups();
 		this.mpsMgr = new MetricProfiles();
@@ -58,19 +64,21 @@ public class PickEndpoints extends FilterFunc {
 
 	}
 
-	public void init() throws IOException {
+	public void init() throws IOException, ParseException {
 		if (this.fsUsed.equalsIgnoreCase("cache")) {
 			this.egMgr.loadAvro(new File("./egroups"));
 			this.ggMgr.loadAvro(new File("./ggroups"));
 			this.mpsMgr.loadAvro(new File("./mps"));
 			this.cfgMgr.loadJson(new File("./cfg"));
 			this.apsMgr.loadJson(new File("./aps"));
+			this.recMgr.loadJson(new File("./rec"));
 		} else if (this.fsUsed.equalsIgnoreCase("local")) {
 			this.egMgr.loadAvro(new File(this.fnEgrp));
 			this.ggMgr.loadAvro(new File(this.fnGgrp));
 			this.mpsMgr.loadAvro(new File(this.fnMps));
 			this.cfgMgr.loadJson(new File(this.fnCfg));
 			this.apsMgr.loadJson(new File(this.fnAps));
+			this.recMgr.loadJson(new File(this.fnRec));
 
 		}
 
@@ -92,6 +100,7 @@ public class PickEndpoints extends FilterFunc {
 		list.add(this.fnCfg.concat("#cfg"));
 		list.add(this.fnMps.concat("#mps"));
 		list.add(this.fnAps.concat("#aps"));
+		list.add(this.fnRec.concat("#rec"));
 		return list;
 	}
 
@@ -104,6 +113,10 @@ public class PickEndpoints extends FilterFunc {
 				LOG.error("Could not initialize sync structures");
 				LOG.error(e);
 				throw new IllegalStateException();
+			} catch (ParseException e) {
+				LOG.error("Could not initialize sync structures due to parsing error");
+				LOG.error(e);
+				throw new IllegalStateException();
 			}
 		}
 
@@ -111,15 +124,20 @@ public class PickEndpoints extends FilterFunc {
 			return false;
 
 		// Check and get tuple input
+		String monHost;
 		String hostname;
 		String service;
 		String metric;
+		String ts;
 
 		try {
 			// Get Arguments
+			
 			hostname = (String) input.get(0);
 			service = (String) input.get(1);
 			metric = (String) input.get(2);
+			monHost = (String) input.get(3);
+			ts = (String) input.get(4);
 		} catch (ClassCastException e) {
 			LOG.error("Failed to cast input to approriate type");
 			LOG.error("Bad tuple input:" + input.toString());
@@ -142,6 +160,17 @@ public class PickEndpoints extends FilterFunc {
 
 		// If filtering by profiles is enabled
 		if (this.filter == 1) {
+			
+			// Filter By monitoring engine 
+			try {
+				if (recMgr.isMonExcluded(monHost, ts) == true){
+					return false;
+				}
+			} catch (ParseException e) {
+				LOG.error("Parsing Error on date");
+				LOG.error(e);
+				throw new IllegalStateException();
+			}
 
 			// Filter By availability profile
 			if (apsMgr.checkService(aprof, service) == false)

--- a/status-computation/java/src/main/java/status/PrepStatusDetails.java
+++ b/status-computation/java/src/main/java/status/PrepStatusDetails.java
@@ -106,12 +106,11 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 			return null;
 
 		// parse input
-		String monitoringHost = (String) input.get(0);
-		String service = (String) input.get(1);
-		String hostname = (String) input.get(2);
-		String metric = (String) input.get(3);
+		String service = (String) input.get(0);
+		String hostname = (String) input.get(1);
+		String metric = (String) input.get(2);
 
-		DefaultDataBag timeline = (DefaultDataBag) input.get(4);
+		DefaultDataBag timeline = (DefaultDataBag) input.get(3);
 		Iterator<Tuple> myit = timeline.iterator();
 		Tuple item;
 
@@ -123,7 +122,8 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 
 		for (int i = 0; i < timeline.size(); i++) {
 			item = myit.next();
-
+			
+		
 			String curTsDate = (String) item.get(0);
 			String curTsDay = curTsDate.substring(0, curTsDate.indexOf("T"));
 
@@ -153,6 +153,8 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 			prevState = (String) item.get(1);
 			prevTs = (String) item.get(0);
 
+			
+			
 			if (curTsDay.equals(this.targetDate)) {
 				outBag.add(item);
 			}
@@ -175,7 +177,6 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 		// add stuff to the output
 		output.append(this.cfgMgr.id); // Add report id
 		output.append(groupBag);
-		output.append(monitoringHost);
 		output.append(service);		   
 		output.append(hostname);
 		output.append(metric);
@@ -189,48 +190,58 @@ public class PrepStatusDetails extends EvalFunc<Tuple> {
 	public Schema outputSchema(Schema input) {
 		Schema.FieldSchema report = new Schema.FieldSchema("report",DataType.CHARARRAY);
 		Schema.FieldSchema endpointGroup = new Schema.FieldSchema("endpoint_group", DataType.CHARARRAY); 
-		Schema.FieldSchema monitoringBox = new Schema.FieldSchema("monitoring_box", DataType.CHARARRAY);
+		
 		Schema.FieldSchema hostname = new Schema.FieldSchema("hostname", DataType.CHARARRAY);
 		Schema.FieldSchema serviceType = new Schema.FieldSchema("service", DataType.CHARARRAY);
 		Schema.FieldSchema metric = new Schema.FieldSchema("metric", DataType.CHARARRAY);
+		
 		
 		Schema.FieldSchema timestamp = new Schema.FieldSchema("timestamp", DataType.CHARARRAY);
 		Schema.FieldSchema status = new Schema.FieldSchema("status", DataType.CHARARRAY);
 		Schema.FieldSchema summary = new Schema.FieldSchema("summary", DataType.CHARARRAY);
 		Schema.FieldSchema message = new Schema.FieldSchema("message", DataType.CHARARRAY);
+		Schema.FieldSchema monitoringBox = new Schema.FieldSchema("monitoring_box", DataType.CHARARRAY);
 		Schema.FieldSchema prevState = new Schema.FieldSchema("previous_state", DataType.CHARARRAY);
 		Schema.FieldSchema prevTs = new Schema.FieldSchema("previous_timestamp", DataType.CHARARRAY);
 		Schema.FieldSchema dateInt = new Schema.FieldSchema("date_integer", DataType.INTEGER);
 		Schema.FieldSchema timeInt = new Schema.FieldSchema("time_integer", DataType.INTEGER);
+		
+		
 
 		Schema.FieldSchema groupName = new Schema.FieldSchema("group_name", DataType.CHARARRAY);
 		
 		Schema statusMetric = new Schema();
 		Schema timeline = new Schema();
+		Schema groupsEnd = new Schema();
 
 		statusMetric.add(report);
 		
 		Schema.FieldSchema groups = null;
 		try {
-			groups = new Schema.FieldSchema("groups", timeline, DataType.BAG);
+			groups = new Schema.FieldSchema("groups",groupsEnd, DataType.BAG);
 		} catch (FrontendException ex) {
 			LOG.error(ex);
 		}
 		
+		groupsEnd.add(groupName);
+		
 		statusMetric.add(groups);
-		statusMetric.add(monitoringBox);
 		statusMetric.add(serviceType);
 		statusMetric.add(hostname);
 		statusMetric.add(metric);
 
+		
+		
 		timeline.add(timestamp);
 		timeline.add(status);
 		timeline.add(summary);
 		timeline.add(message);
+		timeline.add(monitoringBox);
 		timeline.add(prevState);
 		timeline.add(prevTs);
 		timeline.add(dateInt);
 		timeline.add(timeInt);
+		
 
 		Schema.FieldSchema timelines = null;
 		try {

--- a/status-computation/java/src/main/java/sync/Recomputations.java
+++ b/status-computation/java/src/main/java/sync/Recomputations.java
@@ -26,15 +26,18 @@ public class Recomputations {
 	private static final Logger LOG = Logger.getLogger(Recomputations.class.getName());
 
 	public Map<String,ArrayList<Map<String,String>>> groups;
-	
+	// Recomputations for filtering monitoring engine results
+	public Map<String,ArrayList<Map<String,Date>>> monEngines; 
 	
 	public Recomputations() {
 		this.groups = new HashMap<String,ArrayList<Map<String,String>>>();
+		this.monEngines = new HashMap<String,ArrayList<Map<String,Date>>>();
 	}
 
 	// Clear all the recomputation data
 	public void clear() {
 		this.groups = new HashMap<String,ArrayList<Map<String,String>>>();
+		this.monEngines = new HashMap<String,ArrayList<Map<String,Date>>>();
 	}
 	
 	// Insert new recomputation data for a specific endpoint group
@@ -51,11 +54,30 @@ public class Recomputations {
 		this.groups.get(group).add(temp);
 		
 	}
+	
+	// Insert new recomputation data for a specific monitoring engine
+	public void insertMon(String monHost, String start, String end) throws ParseException {
+		
+		Map<String,Date>temp = new HashMap<String,Date>();
+		SimpleDateFormat tsW3C = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		
+		temp.put("s", tsW3C.parse(start));
+		temp.put("e",tsW3C.parse(end));
+		
+		if (this.monEngines.containsKey(monHost) == false){
+			this.monEngines.put(monHost, new ArrayList<Map<String,Date>>());
+		} 
+		
+		this.monEngines.get(monHost).add(temp);
+		
+	}
 
 	// Check if group is excluded in recomputations
 	public boolean isExcluded (String group){
 		return this.groups.containsKey(group);
 	}
+	
+	
 	
 	// Check if a recomputation period is valid for target date
 	public boolean validPeriod(String target, String start, String end) throws ParseException {
@@ -83,10 +105,30 @@ public class Recomputations {
 		
 		return periods;
 	}
+	
+	// 
+	public boolean isMonExcluded(String monHost, String inputTs) throws ParseException{
+		
+		if (this.monEngines.containsKey(monHost) == false)
+		{
+			return false;
+		}
+		SimpleDateFormat tsW3C = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+		Date targetDate = tsW3C.parse(inputTs);
+		for (Map<String, Date> item : this.monEngines.get(monHost))
+		{
+		
+			if  (!(targetDate.before(item.get("s")) || targetDate.after(item.get("e")))) {
+				return true;
+			}
+		}
+		
+		return false;
+	}
 
 	
 
-	public void loadJson(File jsonFile) throws IOException {
+	public void loadJson(File jsonFile) throws IOException, ParseException {
 
 		this.clear();
 
@@ -99,13 +141,32 @@ public class Recomputations {
 			JsonArray jRootObj = jRootElement.getAsJsonArray();
 
 			for (JsonElement item : jRootObj) {
-				String start = item.getAsJsonObject().get("start_time").getAsString();
-				String end = item.getAsJsonObject().get("end_time").getAsString();
-
-				// Get the excluded
-				JsonArray jExclude = item.getAsJsonObject().get("exclude").getAsJsonArray();
-				for (JsonElement subitem : jExclude) {
-					this.insert(subitem.getAsString(),start,end);
+				
+				// Get the excluded sites 
+				if (item.getAsJsonObject().get("start_time") != null  
+						&& item.getAsJsonObject().get("end_time") != null
+						&& item.getAsJsonObject().get("exclude") != null )  {
+				
+					String start = item.getAsJsonObject().get("start_time").getAsString();
+					String end = item.getAsJsonObject().get("end_time").getAsString();
+		
+					// Get the excluded
+					JsonArray jExclude = item.getAsJsonObject().get("exclude").getAsJsonArray();
+					for (JsonElement subitem : jExclude) {
+						this.insert(subitem.getAsString(),start,end);
+					}
+				}
+				
+				// Get the excluded Monitoring sources
+				if (item.getAsJsonObject().get("exclude_monitoring_source") != null) {
+					JsonArray jMon = item.getAsJsonObject().get("exclude_monitoring_source").getAsJsonArray();
+					for (JsonElement subitem: jMon){
+						
+						String monHost = subitem.getAsJsonObject().get("host").getAsString();
+						String monStart = subitem.getAsJsonObject().get("start_time").getAsString();
+						String monEnd = subitem.getAsJsonObject().get("end_time").getAsString();
+						this.insertMon(monHost, monStart, monEnd);
+					}
 				}
 
 			}
@@ -114,6 +175,9 @@ public class Recomputations {
 			LOG.error("Could not open file:" + jsonFile.getName());
 			throw ex;
 
+		} catch (ParseException pex) {
+			LOG.error("Parsing date error");
+			throw pex;
 		} finally {
 			// Close quietly without exceptions the buffered reader
 			IOUtils.closeQuietly(br);

--- a/status-computation/java/src/test/java/ar/PickEndpointsTest.java
+++ b/status-computation/java/src/test/java/ar/PickEndpointsTest.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.text.ParseException;
 
 import ops.OpsManagerTest;
 
@@ -21,30 +22,58 @@ import sync.GroupsOfGroupsTest;
 public class PickEndpointsTest {
 
 	@Test
-	public void test() throws URISyntaxException, IOException {
+	public void test() throws URISyntaxException, IOException, ParseException {
 		// Prepare Resource File
 		URL metricRes = EndpointGroupsTest.class.getResource("/avro/poem_sync_v2.avro");
 		File metricAvro = new File(metricRes.toURI());
 
 		URL groupEndpointRes = GroupsOfGroupsTest.class.getResource("/avro/group_endpoints_v2.avro");
 		File groupEndpointAvro = new File(groupEndpointRes.toURI());
+		
+		URL groupGroupsRes = GroupsOfGroupsTest.class.getResource("/avro/group_groups_v2.avro");
+		File groupGroupsAvro = new File(groupGroupsRes.toURI());
 
 		URL apsRes = GroupsOfGroupsTest.class.getResource("/ops/ap1.json");
 		File apsJson = new File(apsRes.toURI());
+		
+		URL recRes = GroupsOfGroupsTest.class.getResource("/ops/recomp.json");
+		File recJson = new File(recRes.toURI());
+		
+		URL cfgRes = GroupsOfGroupsTest.class.getResource("/ops/config.json");
+		File cfgJson = new File(cfgRes.toURI());
 
-		PickEndpoints pt = new PickEndpoints("", "", "", "", "", "1", "test");
+		PickEndpoints pt = new PickEndpoints("","", "", "", "", "", "1", "test");
 
 		pt.mpsMgr.loadAvro(metricAvro);
 		pt.egMgr.loadAvro(groupEndpointAvro);
+		pt.ggMgr.loadAvro(groupGroupsAvro);
 		pt.apsMgr.loadJson(apsJson);
+		pt.recMgr.loadJson(recJson);
+		pt.cfgMgr.loadJson(cfgJson);
 
+		
+		
 		TupleFactory tf = TupleFactory.getInstance();
+		
+		// Exclude because of monitoring engine
 		Tuple inp = tf.newTuple();
 		inp.append("se01.afroditi.hellasgrid.gr");
-		inp.append("SRM");
+		inp.append("SRMv2");
 		inp.append("org.sam.SRM-Ls");
+		inp.append("monA");
+		inp.append("2013-12-08T13:03:44Z");
 
-		System.out.println(pt.exec(inp));
+		assertEquals(false,pt.exec(inp));
+		
+		Tuple inp2 = tf.newTuple();
+		inp2.append("se01.afroditi.hellasgrid.gr");
+		inp2.append("SRMv2");
+		inp2.append("org.sam.SRM-Ls");
+		inp2.append("monB");
+		inp2.append("2013-12-08T13:03:44Z");
+		
+		
+		assertEquals(true,pt.exec(inp2));
 
 	}
 

--- a/status-computation/java/src/test/java/sync/RecomputationsTest.java
+++ b/status-computation/java/src/test/java/sync/RecomputationsTest.java
@@ -3,7 +3,6 @@ package sync;
 import static org.junit.Assert.*;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -12,7 +11,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import ops.OpsManagerTest;
+
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -34,6 +33,7 @@ public class RecomputationsTest {
 
 		Recomputations recMgr = new Recomputations();
 		recMgr.loadJson(jsonFile);
+		
 
 		assertEquals(recMgr.isExcluded("GR-01-AUTH"), true);
 		assertEquals(recMgr.isExcluded("HG-03-AUTH"), true);
@@ -49,6 +49,7 @@ public class RecomputationsTest {
 		
 		Map<String,String> siteA1map = new HashMap<String, String>();
 		Map<String,String> siteA2map = new HashMap<String, String>();
+		
 		
 		
 		Map<String,String> siteBmap = new HashMap<String,String>();
@@ -80,6 +81,23 @@ public class RecomputationsTest {
 	    Assert.assertEquals(recMgr.getPeriods("GR-01-AUTH", "2013-12-08"),gr01list);
 	    Assert.assertEquals(recMgr.getPeriods("SITE-A", "2013-12-08"),siteAlist);
 	    Assert.assertEquals(recMgr.getPeriods("SITE-B", "2013-12-08"),siteBlist);
+	    
+	    // check monitoring exclusions
+	    Assert.assertEquals(false,recMgr.isMonExcluded("monA", "2013-12-08T11:03:43Z"));
+	    Assert.assertEquals(false,recMgr.isMonExcluded("monA", "2013-12-08T11:03:44Z"));
+	    Assert.assertEquals(true,recMgr.isMonExcluded("monA", "2013-12-08T12:06:44Z"));
+	    Assert.assertEquals(true,recMgr.isMonExcluded("monA", "2013-12-08T14:05:44Z"));
+	    Assert.assertEquals(true,recMgr.isMonExcluded("monA", "2013-12-08T15:02:44Z"));
+	    Assert.assertEquals(false,recMgr.isMonExcluded("monA", "2013-12-08T15:03:45Z"));
+	    
+	    // check monitoring exclusions
+	    Assert.assertEquals(false,recMgr.isMonExcluded("monB", "2013-12-08T11:03:43Z"));
+	    Assert.assertEquals(false,recMgr.isMonExcluded("monB", "2013-12-08T11:03:44Z"));
+	    Assert.assertEquals(false,recMgr.isMonExcluded("monB", "2013-12-08T12:06:44Z"));
+	    Assert.assertEquals(false,recMgr.isMonExcluded("monB", "2013-12-08T14:05:44Z"));
+	    Assert.assertEquals(false,recMgr.isMonExcluded("monB", "2013-12-08T15:02:44Z"));
+	    Assert.assertEquals(false,recMgr.isMonExcluded("monB", "2013-12-08T15:03:45Z"));
+	    
 	}
 
 }

--- a/status-computation/java/src/test/resources/ops/recomp.json
+++ b/status-computation/java/src/test/resources/ops/recomp.json
@@ -18,7 +18,17 @@
     "SITE-B"
   ],
   "status": "running",
-  "timestamp": "2015-02-01 14:58:40"
+  "timestamp": "2015-02-01 14:58:40",
+  "exclude_monitoring_source": [
+  	{ "host": "monA",
+  	  "start_time": "2013-12-08T12:03:44Z",
+  	  "end_time": "2013-12-08T15:03:44Z"
+  	},
+  	{ "host": "monA",
+  	  "start_time": "2013-12-08T18:03:44Z",
+  	  "end_time": "2013-12-08T19:03:44Z"
+  	}
+  ]
 },
 {
   "reason": "testing_compute_engine",


### PR DESCRIPTION
### Issue 
Change CE to accept data from multiple monitoring engines ...thus multiple values in the `monitoring_host` avro field
Be able to exclude metric data for specific time periods for problematic monitoring engines (based again on `monitoring_host` field and `timestamp`)

### Resolution
Append extra information about excluding monitoring engines in the available recomputation schema

__Previous recomputation schema:__
```json
[{
  "reason": "testing_compute_engine",
  "start_time": "2013-12-08T12:03:44Z",
  "end_time": "2013-12-10T12:03:44Z",
  "exclude": [
    "SITE-A",
    "SITE-B"
  ],
  "status": "running",
  "timestamp": "2015-02-01 14:58:40"
}]
```

__Refactored recomputation schema:__
```json
[{
  "reason": "testing_compute_engine",
  "start_time": "2013-12-08T12:03:44Z",
  "end_time": "2013-12-10T12:03:44Z",
  "exclude": [
    "SITE-A",
    "SITE-B"
  ],
  "status": "running",
  "timestamp": "2015-02-01 14:58:40",
  "exclude_monitoring_source": [
  	{ "host": "monA",
  	  "start_time": "2013-12-08T12:03:44Z",
  	  "end_time": "2013-12-08T15:03:44Z"
  	}]
}]
```

### Implementation
- [x] Accept metric data for different `monitoring_host` values
- [x] Parse extra `monitoring` field in recomputation.json inside RecomputationManager class
- [x] Ask RecomputationManager if a monitoring engine is excluded for a specific timestamp
- [x] Use Refactored RecompManager in PickEndpoints Filter UDF to filter metric data based on `monitoring_host` and `timestamp`
- [x] Add unittests for both recManager and PickEndpoints UDF
- [x] Update accordingly compute-ar.pig, compute-status.pig UDF definitions and calls