### PR TITLE
ARGO-346 Modify downtimes calling method in upload_sync.py utility to read tenant-wise configuration.

### DIFF
--- a/bin/upload_sync.py
+++ b/bin/upload_sync.py
@@ -48,7 +48,8 @@ def main(args=None):
     ArConfig = SafeConfigParser()
     ArConfig.read(fn_ar_cfg)
 
-    # Get sync exec and path
+    # Get sync conf, exec and path
+    arsync_conf = ArConfig.get('connectors', 'sync_conf')
     arsync_exec = ArConfig.get('connectors', 'sync_exec')
     arsync_lib = ArConfig.get('connectors', 'sync_path')
 
@@ -100,7 +101,8 @@ def main(args=None):
 
     # Call downtimes latest info
     cmd_call_downtimes = [
-        os.path.join(arsync_exec, 'downtimes-gocdb-connector.py'), '-d', args.date]
+        os.path.join(arsync_exec, 'downtimes-gocdb-connector.py'), '-d', args.date,
+        '-c', os.path.join(arsync_conf, args.tenant.lower() + '-customer.conf')]
     log.info("Calling downtime sync connector to give us latest downtime info")
 
     run_cmd(cmd_call_downtimes, log)

--- a/conf/ar-compute-engine.conf.template
+++ b/conf/ar-compute-engine.conf.template
@@ -51,6 +51,7 @@ hadoop_log_root=INFO,console
 
 [connectors]
 
+sync_conf=/etc/argo-egi-connectors/
 sync_exec=/usr/libexec/ar-sync/
 sync_path=/var/lib/ar-sync/
 


### PR DESCRIPTION
# Description

After the latest induced changes on the connectors (per customer configuration files) a change is needed in the compute engine with regard to the downtimes connector and how it should be called from within the CE framework. 

please review /cc @kaggis 