### PR TITLE
ARGO-350 Add Flume Decode Interceptor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ script:
  - py.test ./bin/ --junitxml=./bin/junit.xml
 # Run unittests and generate reports on java src
  - cd status-computation/java && mvn test
+ - cd ../../flume/decode_interceptor/ && mvn test

--- a/doc/flume_decode_interceptor.md
+++ b/doc/flume_decode_interceptor.md
@@ -1,0 +1,76 @@
+---
+title: Compute Engine documentation | ARGO
+page_title: Compute Engine Ingestion: Flume Decode Interceptor
+font_title: 'fa fa-cog'
+description: Using a custom flume interceptor while ingesting data from kafka to hdfs
+---
+
+When using the ARGO Messaging API for ingestion in-front of the compute engine, a broker network is needed for the relay of messages and an ingestion mechanism for storing the data on HDFS. The ingestion mechanism used is the flume service.
+
+ARGO Messaging API produces JSON messages in the following schema:
+
+```
+json
+{
+   "messageId": "12",
+   "attributes": [
+      {
+         "key": "foo",
+         "value": "bar"
+      }
+   ],
+   "data": "dGhpcyBpcyB0aGUgcGF5bG9hZA==",
+   "publishTime": "2016-03-09T13:02:21.139873825Z"
+}
+```
+
+Notice that the payload is included in the "data" field and is encoded in base64. Usually in the compute engine the
+encoded payload when decoded will result in a binary AVRO file.
+
+Flume is configured to listen to a KAFKA source (broker network) and transfer though a memory channel each event to an HDFS sink (destination).
+
+##  The need for the interceptor
+
+In order to keep only the integral part of the payload and transfer it decoded to it's final destination we need to define a flume
+interceptor on the KAFKA source. Interceptors give the ability to flume to drop or modify events. Interceptors are actually JAVA classes that implement the Interceptor Interface. Flume comes with a bunch of build in interceptors but gives also the ability to define custom ones.
+
+For the ingestion part of the Compute Engine a custom flume Decode Interceptor was developed as a small maven project.
+
+## How to test the Decode Interceptor
+
+The Decode Interceptor project is hosted in the directory `/flume/decode_interceptor` of the argo-compute-engine repo.
+
+To build the jar file use the following commands:
+
+- `cd /flume/decode_interceptor`
+- `mvn clean`
+- `mvn package`
+
+The build process produces the following file:
+```
+/flume/decode_interceptor/target/decode-interceptor-x.y.z-SNAPSHOT.jar
+```
+_(where x,y,z are integers used for versioning)_
+
+To only test the interceptor, just issue
+- `cd /flume/decode_interceptor`
+- `mvn test`
+
+
+## How to deploy the Decode Interceptor at flume node
+
+This file must be deployed to the node that flume-agent runs
+At flume-agent node, deploy the JAR file to the following path (please create if doesn't exist)
+
+```
+/usr/lib/flume-ng/plugins.d/decode_interceptor/lib/
+```
+
+Then on the flume configuration file the interceptor must be added to the relevant source
+for e.g.
+
+_Contents of flume configuration file:_
+```
+flume1.sources.kafka-source-1.interceptors = DecodeInterceptor
+flume1.sources.kafka-source-1.interceptors.DecodeInterceptor.type=argo.DecodeInterceptor$Builder
+```

--- a/flume/decode_interceptor/pom.xml
+++ b/flume/decode_interceptor/pom.xml
@@ -1,0 +1,82 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>argo</groupId>
+	<artifactId>decode-interceptor</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>decode-interceptor</name>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.3.2</version>
+				<configuration>
+					<source>1.6</source>
+					<target>1.6</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>cobertura-maven-plugin</artifactId>
+				<version>2.7</version>
+				<configuration>
+					<formats>
+						<format>xml</format>
+					</formats>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>cobertura</goal>
+						</goals>
+					</execution>
+				</executions>
+			
+			</plugin>
+		</plugins>
+	</build>
+
+
+	<dependencies>
+
+		<dependency>
+			<groupId>org.apache.flume</groupId>
+			<artifactId>flume-ng-sdk</artifactId>
+			<version>1.6.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flume</groupId>
+			<artifactId>flume-ng-core</artifactId>
+			<version>1.6.0</version>
+		</dependency>
+		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+			<version>1.2.17</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>20041127.091804</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit-addons</groupId>
+			<artifactId>junit-addons</artifactId>
+			<version>1.4</version>
+		</dependency>
+	</dependencies>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+</project>

--- a/flume/decode_interceptor/src/main/java/argo/flume/interceptor/DecodeInterceptor.java
+++ b/flume/decode_interceptor/src/main/java/argo/flume/interceptor/DecodeInterceptor.java
@@ -1,0 +1,129 @@
+package argo.flume.interceptor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.flume.Context;
+import org.apache.flume.Event;
+import org.apache.flume.interceptor.Interceptor;
+import org.apache.log4j.Logger;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+
+public class DecodeInterceptor implements Interceptor {
+
+	// Prepare Logger
+	private static final Logger LOG = Logger.getLogger(DecodeInterceptor.class);
+	
+
+	public static class Builder implements Interceptor.Builder {
+
+		/**
+		 * Called from builder class to build DecodeInterceptor
+		 */
+		@Override
+		public Interceptor build() {
+			return new DecodeInterceptor();
+		}
+
+		/**
+		 * Called from builder class to grab flume configuration parameters
+		 */
+		@Override
+		public void configure(Context flumeCtx) {
+
+		}
+	}
+
+	/**
+	 * Private constructor of class
+	 * <p>
+	 * Called from Builder 
+	 */
+	private DecodeInterceptor() {
+	}
+
+	/**
+	 * Called when interceptor is initialized
+	 * <p>
+	 * Just log info that interceptor was initialized 
+	 */
+	@Override
+	public void initialize() {
+		LOG.info("Interceptor Initialized");
+	}
+
+	/**
+	 * Intercepts an event from flume pipeline 
+	 * <p>
+	 * This method is called for each signle event that interceptor picks up
+	 * 
+	 * @param event
+	 *            An Event object containing the flume event
+	 */
+	@Override
+	public Event intercept(Event event) {
+	
+		try {
+			// Grab the event body = actual json message from broker network
+			String body = new String(event.getBody());
+			// create a new parser for json msg
+			JsonParser jsonParser = new JsonParser();
+			// parse the json root object
+			JsonElement jRoot = jsonParser.parse(body);
+			// parse the json field "data" and read it as string
+			// this is the base64 string payload
+			String data = jRoot.getAsJsonObject().get("data").getAsString();
+			// decode the base64 payload into it's original form
+			byte[] decoded =  Base64.decodeBase64(data.getBytes("UTF-8"));
+			// replace the whole event body with the newly decoded bytes
+			event.setBody(decoded);
+	
+		} catch (Exception e) {
+			// On exception log the message 
+			// this usually goes to /var/log/flume/
+			LOG.warn(e.getMessage());
+			return null;
+		}
+		
+		// return the event to flume pipeline
+		return event;
+	}
+
+	/**
+	 * Intercepts an batch of events from flume pipeline
+	 * <p>
+	 * This method is called for a batch(list) of events captured by interceptor
+	 * 
+	 * @param events
+	 *            A List of Event objects containing the flume events captured
+	 */
+	@Override
+	public List<Event> intercept(List<Event> events) {
+		List<Event> passEvents = new ArrayList<Event>();
+
+		for (Event event : events) {
+			Event handledEvent = intercept(event);
+
+			if (handledEvent != null) {
+				passEvents.add(handledEvent);
+			}
+		}
+		return passEvents;
+	}
+
+	
+	/**
+	 * Called when interceptor is closed
+	 * <p>
+	 * Just log info that interceptor was closed
+	 */
+	@Override
+	public void close() {
+		LOG.info("Interceptor closed");
+	}
+
+}

--- a/flume/decode_interceptor/src/test/java/argo/flume/interceptor/DecodeInterceptorTest.java
+++ b/flume/decode_interceptor/src/test/java/argo/flume/interceptor/DecodeInterceptorTest.java
@@ -1,0 +1,48 @@
+package argo.flume.interceptor;
+
+import org.junit.Assert;
+import org.apache.commons.io.IOUtils;
+import org.apache.flume.Event;
+import org.apache.flume.event.EventBuilder;
+import org.junit.Test;
+
+import argo.flume.interceptor.DecodeInterceptor;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+public class DecodeInterceptorTest {
+
+	@Test
+	public void TestIntercept() throws IOException, URISyntaxException {
+
+		// Prepare Resource File
+		URL resJsonFile = DecodeInterceptorTest.class.getResource("/event_body.json");
+		File jsonFile = new File(resJsonFile.toURI());
+		FileInputStream jsonFileStream = new FileInputStream(jsonFile);
+		// Read the file contents into a string
+		String jsonStr = IOUtils.toString(jsonFileStream, "UTF-8");
+
+		// Create a new Flume Event object
+		Event flumeEvent = EventBuilder.withBody(jsonStr.getBytes());
+
+		// Prepare Builder to create a DecodeInterceptor Test Instance
+		DecodeInterceptor.Builder bd = new DecodeInterceptor.Builder();
+		DecodeInterceptor testDec = (DecodeInterceptor) bd.build();
+
+		// Use Intercept method to produce output event
+		Event output = testDec.intercept(flumeEvent);
+
+		// This is the expected Message
+		String expectedMsg = "this has to be decoded";
+		// This is the output message body
+		String outputMsg = new String(output.getBody());
+
+		// Assert they are equal
+		Assert.assertEquals(expectedMsg, outputMsg);
+
+	}
+}

--- a/flume/decode_interceptor/src/test/java/log4j.properties
+++ b/flume/decode_interceptor/src/test/java/log4j.properties
@@ -1,0 +1,6 @@
+log4j.rootLogger=WARN,A1
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c %x - %m%n

--- a/flume/decode_interceptor/src/test/resources/event_body.json
+++ b/flume/decode_interceptor/src/test/resources/event_body.json
@@ -1,0 +1,9 @@
+{
+      "attributes": [
+        {
+          "key": "purpose",
+          "value": "test for interceptor"
+        }
+      ],
+   "data": "dGhpcyBoYXMgdG8gYmUgZGVjb2RlZA=="
+}


### PR DESCRIPTION
### Goal

When using ARGO Messaging API for ingestrion through flume, CE should use a flume interceptor to extract and decode the pure payload of the msgs received from the API. 

### Implementation

This Custom Flume interceptor is implemented as DecodeInterceptor Java class in a small maven project. 

The Interceptor purpose:
 - Intecept the event (calling intercept() method)
 - Extract json field "data"
 - Base64 decode field's (data) value
 - set event body to the decoded value
 - Return the event

The maven project is implemented in the `./flume/decode_interceptor/' directory


 