### PR TITLE
ARGO-330 Fill Missing Endpoints when absent from metric data

### DIFF
--- a/status-computation/java/src/main/java/ar/FillMissing.java
+++ b/status-computation/java/src/main/java/ar/FillMissing.java
@@ -1,0 +1,176 @@
+package ar;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.apache.pig.EvalFunc;
+import org.apache.pig.backend.executionengine.ExecException;
+import org.apache.pig.data.BagFactory;
+import org.apache.pig.data.DataBag;
+import org.apache.pig.data.DataType;
+import org.apache.pig.data.Tuple;
+import org.apache.pig.data.TupleFactory;
+import org.apache.pig.impl.logicalLayer.FrontendException;
+import org.apache.pig.impl.logicalLayer.schema.Schema;
+
+import ops.ConfigManager;
+import sync.EndpointGroups;
+import sync.MetricProfiles;
+
+public class FillMissing extends EvalFunc<Tuple> {
+
+	private static final Logger LOG = Logger.getLogger(AddGroupInfo.class.getName());
+	private String fnCfg;
+	private String fnMps;
+	private String targetDate;
+
+	private TupleFactory tupFactory;
+	private BagFactory bagFactory;
+	
+	public ConfigManager cfgMgr;
+	public MetricProfiles mpsMgr;
+	
+	private String fsUsed; // local,hdfs,cache (distrubuted_cache)
+	
+	private boolean initialized;
+
+	public FillMissing(String targetDate, String fnConfig, String fsUsed) {
+		
+
+		this.fsUsed = fsUsed;
+
+		this.fnCfg = fnConfig;
+		
+		this.targetDate = targetDate;
+		
+		this.cfgMgr = new ConfigManager();
+		
+		
+		
+		// set up factories
+		this.tupFactory = TupleFactory.getInstance();
+		this.bagFactory = BagFactory.getInstance();
+	}
+
+	public void init() throws IOException {
+		if (this.fsUsed.equalsIgnoreCase("cache")) {
+			this.cfgMgr.loadJson(new File("./cfg"));
+			
+		} else if (this.fsUsed.equalsIgnoreCase("local")) {
+			
+			this.cfgMgr.loadJson(new File(this.fnCfg));
+			
+		}
+
+		this.initialized = true;
+	}
+
+	public List<String> getCacheFiles() {
+		List<String> list = new ArrayList<String>();
+		list.add(this.fnCfg.concat("#cfg"));
+		return list;
+	}
+
+	@Override
+	public Tuple exec(Tuple input) {
+
+		// Check if cache files have been opened
+		if (this.initialized == false) {
+			try {
+				this.init();
+			} catch (IOException e) {
+				LOG.error("Could not initialize sync structures");
+				LOG.error(e);
+				throw new IllegalStateException(e);
+			}
+		}
+
+		if (input == null || input.size() == 0)
+			return null;
+		
+		String service;
+		String hostname;
+		String metric;
+		try {
+			service = (String) input.get(0);
+			hostname = (String) input.get(1);
+			metric = (String) input.get(2);
+			
+		} catch (ClassCastException e) {
+			LOG.error("Failed to cast input to approriate type");
+			LOG.error("Bad tuple input:" + input.toString());
+			LOG.error(e);
+			throw new IllegalArgumentException();
+		} catch (IndexOutOfBoundsException e) {
+			LOG.error("Malformed tuple schema");
+			LOG.error("Bad tuple input:" + input.toString());
+			LOG.error(e);
+			throw new IllegalArgumentException();
+		} catch (ExecException e) {
+			LOG.error("Execution error");
+			LOG.error(e);
+			throw new IllegalArgumentException();
+		}
+		
+		
+		
+		
+		Tuple output = tupFactory.newTuple();
+		
+		output.append(cfgMgr.id);
+		output.append("none");
+		output.append(service);
+		output.append(hostname);
+		output.append(metric);
+		output.append(targetDate+"T00:00:00Z");
+		output.append("MISSING");
+		output.append("missing");
+		output.append("missing");
+		
+		return output;
+	}
+
+	@Override
+	public Schema outputSchema(Schema input) {
+
+		Schema.FieldSchema report = new Schema.FieldSchema("report", DataType.CHARARRAY);
+		Schema.FieldSchema monBox = new Schema.FieldSchema("monitoring_box", DataType.CHARARRAY);
+	
+		Schema.FieldSchema service = new Schema.FieldSchema("service", DataType.CHARARRAY);
+		Schema.FieldSchema hostname = new Schema.FieldSchema("hostname", DataType.CHARARRAY);
+		Schema.FieldSchema metric = new Schema.FieldSchema("metric", DataType.CHARARRAY);
+		
+		Schema.FieldSchema ts = new Schema.FieldSchema("timestamp", DataType.CHARARRAY);
+		Schema.FieldSchema status = new Schema.FieldSchema("status", DataType.CHARARRAY);
+		
+		Schema.FieldSchema msg = new Schema.FieldSchema("message", DataType.CHARARRAY);
+		Schema.FieldSchema sum = new Schema.FieldSchema("summary", DataType.CHARARRAY);
+		
+		Schema endpoint = new Schema();
+	
+		
+		endpoint.add(report);
+		endpoint.add(monBox);
+		endpoint.add(service);
+		endpoint.add(hostname);
+		endpoint.add(metric);
+		endpoint.add(ts);
+		endpoint.add(status);
+		endpoint.add(msg);
+		endpoint.add(sum);
+		
+
+		try {
+			return new Schema(new Schema.FieldSchema("endpoint", endpoint, DataType.TUPLE));
+		} catch (FrontendException ex) {
+			LOG.error(ex);
+		}
+
+		return null;
+
+	}
+
+}

--- a/status-computation/java/src/main/java/ar/UnwindServiceMetrics.java
+++ b/status-computation/java/src/main/java/ar/UnwindServiceMetrics.java
@@ -1,0 +1,177 @@
+package ar;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+import org.apache.pig.EvalFunc;
+import org.apache.pig.backend.executionengine.ExecException;
+import org.apache.pig.data.BagFactory;
+import org.apache.pig.data.DataBag;
+import org.apache.pig.data.DataType;
+import org.apache.pig.data.Tuple;
+import org.apache.pig.data.TupleFactory;
+import org.apache.pig.impl.logicalLayer.FrontendException;
+import org.apache.pig.impl.logicalLayer.schema.Schema;
+
+
+import sync.MetricProfiles;
+
+public class UnwindServiceMetrics extends EvalFunc<Tuple> {
+
+	private static final Logger LOG = Logger.getLogger(AddGroupInfo.class.getName());
+	private String fnMps;
+
+	private TupleFactory tupFactory;
+	private BagFactory bagFactory;
+	
+	public MetricProfiles mpsMgr;
+	
+	private String fsUsed; // local,hdfs,cache (distrubuted_cache)
+	
+	private boolean initialized;
+
+	public UnwindServiceMetrics (String fnMps, String fsUsed) {
+		
+
+		this.fsUsed = fsUsed;
+
+		this.fnMps = fnMps;
+		
+	
+		this.mpsMgr = new MetricProfiles();
+		
+		
+		// set up factories
+		this.tupFactory = TupleFactory.getInstance();
+		this.bagFactory = BagFactory.getInstance();
+	}
+
+	public void init() throws IOException {
+		if (this.fsUsed.equalsIgnoreCase("cache")) {
+	
+			this.mpsMgr.loadAvro(new File("./mps"));
+		} else if (this.fsUsed.equalsIgnoreCase("local")) {
+			
+			
+			this.mpsMgr.loadAvro(new File(this.fnMps));
+		}
+
+		this.initialized = true;
+	}
+
+	public List<String> getCacheFiles() {
+		List<String> list = new ArrayList<String>();
+		list.add(this.fnMps.concat("#mps"));
+		return list;
+	}
+
+	@Override
+	public Tuple exec(Tuple input) {
+
+		// Check if cache files have been opened
+		if (this.initialized == false) {
+			try {
+				this.init();
+			} catch (IOException e) {
+				LOG.error("Could not initialize sync structures");
+				LOG.error(e);
+				throw new IllegalStateException(e);
+			}
+		}
+
+		if (input == null || input.size() == 0)
+			return null;
+
+		if (this.mpsMgr.getProfiles() == null){
+			throw new IllegalStateException("metric profile not initialized");
+		}
+		
+		String service;
+		String hostname;
+		try {
+			service = (String) input.get(0);
+			hostname = (String) input.get(1);
+			
+		} catch (ClassCastException e) {
+			LOG.error("Failed to cast input to approriate type");
+			LOG.error("Bad tuple input:" + input.toString());
+			LOG.error(e);
+			throw new IllegalArgumentException();
+		} catch (IndexOutOfBoundsException e) {
+			LOG.error("Malformed tuple schema");
+			LOG.error("Bad tuple input:" + input.toString());
+			LOG.error(e);
+			throw new IllegalArgumentException();
+		} catch (ExecException e) {
+			LOG.error("Execution error");
+			LOG.error(e);
+			throw new IllegalArgumentException();
+		}
+		
+		// Add the relevant metric profiles
+		DataBag metricBag = bagFactory.newDefaultBag();
+		// Get the first and only one metric profile
+		String mProf = this.mpsMgr.getProfiles().get(0);
+		ArrayList<String> metrics = this.mpsMgr.getProfileServiceMetrics(mProf, service);
+		
+		if (metrics == null) {
+			return null;
+		}
+		
+		for (String metric : metrics)
+		{
+			Tuple cur_tupl = tupFactory.newTuple();
+			cur_tupl.append(metric);
+			metricBag.add(cur_tupl);
+		}
+		
+		
+		Tuple output = tupFactory.newTuple();
+		
+		output.append(service);
+		output.append(hostname);
+		output.append(metricBag);
+		
+		return output;
+	}
+
+	@Override
+	public Schema outputSchema(Schema input) {
+
+	
+		Schema.FieldSchema service = new Schema.FieldSchema("service", DataType.CHARARRAY);
+		Schema.FieldSchema hostname = new Schema.FieldSchema("hostname", DataType.CHARARRAY);
+		
+		
+				
+		Schema endpoint = new Schema();
+		Schema metrics = new Schema();
+		
+		Schema.FieldSchema mtr = null;
+		try {
+			mtr = new Schema.FieldSchema("metrics", metrics, DataType.BAG);
+		} catch (FrontendException ex) {
+			LOG.error(ex);
+		}
+		
+		
+		endpoint.add(service);
+		endpoint.add(hostname);
+		endpoint.add(mtr);
+	
+		
+
+		try {
+			return new Schema(new Schema.FieldSchema("endpoint", endpoint, DataType.TUPLE));
+		} catch (FrontendException ex) {
+			LOG.error(ex);
+		}
+
+		return null;
+
+	}
+
+}

--- a/status-computation/java/src/test/java/ar/FillMissingTest.java
+++ b/status-computation/java/src/test/java/ar/FillMissingTest.java
@@ -1,0 +1,50 @@
+package ar;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.pig.data.BagFactory;
+import org.apache.pig.data.DataBag;
+import org.apache.pig.data.Tuple;
+import org.apache.pig.data.TupleFactory;
+import org.junit.Test;
+
+import TestIO.JsonToPig;
+import ops.OpsManagerTest;
+import sync.EndpointGroupsTest;
+import sync.GroupsOfGroupsTest;
+
+public class FillMissingTest {
+
+	@Test
+	public void test() throws IOException, URISyntaxException {
+		// Prepare Resource File
+		URL cfgFilePath = OpsManagerTest.class.getResource("/ops/config.json");
+		File cfgJson = new File(cfgFilePath.toURI());
+
+		FillMissing fm = new FillMissing("2015-01-01","", "test");
+
+		fm.cfgMgr.loadJson(cfgJson);
+
+		TupleFactory tf = TupleFactory.getInstance();
+
+		Tuple inTuple = tf.newTuple();
+
+		inTuple.append("SRMv2");
+		inTuple.append("se01.afroditi.hellasgrid.gr");
+		inTuple.append("org.sam.SRM-Put");
+
+		String jsonStr = IOUtils.toString(this.getClass().getResourceAsStream("/ar/missing_endpoint_full.json"), "UTF-8");
+		Tuple expTuple = JsonToPig.jsonToTuple(jsonStr);
+		Tuple outTuple = fm.exec(inTuple);
+		
+		assertTrue(expTuple.toString().equals(outTuple.toString()));
+
+	}
+
+}

--- a/status-computation/java/src/test/java/ar/UnwindServiceMetricsTest.java
+++ b/status-computation/java/src/test/java/ar/UnwindServiceMetricsTest.java
@@ -1,0 +1,48 @@
+package ar;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.pig.data.BagFactory;
+import org.apache.pig.data.DataBag;
+import org.apache.pig.data.Tuple;
+import org.apache.pig.data.TupleFactory;
+import org.junit.Test;
+
+import TestIO.JsonToPig;
+import sync.EndpointGroupsTest;
+import sync.GroupsOfGroupsTest;
+
+public class UnwindServiceMetricsTest {
+
+	@Test
+	public void test() throws IOException, URISyntaxException {
+		// Prepare Resource File
+		URL metricRes = EndpointGroupsTest.class.getResource("/avro/poem_sync_v2.avro");
+		File metricAvro = new File(metricRes.toURI());
+
+		UnwindServiceMetrics uw = new UnwindServiceMetrics("", "test");
+
+		uw.mpsMgr.loadAvro(metricAvro);
+
+		TupleFactory tf = TupleFactory.getInstance();
+
+		Tuple inTuple = tf.newTuple();
+
+		inTuple.append("SRMv2");
+		inTuple.append("se01.afroditi.hellasgrid.gr");
+
+		String jsonStr = IOUtils.toString(this.getClass().getResourceAsStream("/ar/missing_endpoint.json"), "UTF-8");
+		Tuple expTuple = JsonToPig.jsonToTuple(jsonStr);
+		Tuple outTuple = uw.exec(inTuple);
+		
+		assertTrue(expTuple.toString().equals(outTuple.toString()));
+
+	}
+
+}

--- a/status-computation/java/src/test/resources/ar/missing_endpoint.json
+++ b/status-computation/java/src/test/resources/ar/missing_endpoint.json
@@ -1,0 +1,30 @@
+{
+  "service": "SRMv2",
+  "hostname": "se01.afroditi.hellasgrid.gr",
+  "metrics": [
+    {
+      "metric": "hr.srce.SRM2-CertLifetime"
+    },
+    {
+      "metric": "org.sam.SRM-Del"
+    },
+    {
+      "metric": "org.sam.SRM-Get"
+    },
+    {
+      "metric": "org.sam.SRM-GetSURLs"
+    },
+    {
+      "metric": "org.sam.SRM-GetTURLs"
+    },
+    {
+      "metric": "org.sam.SRM-Ls"
+    },
+    {
+      "metric": "org.sam.SRM-LsDir"
+    },
+    {
+      "metric": "org.sam.SRM-Put"
+    }
+  ]
+}

--- a/status-computation/java/src/test/resources/ar/missing_endpoint_full.json
+++ b/status-computation/java/src/test/resources/ar/missing_endpoint_full.json
@@ -1,0 +1,11 @@
+{
+  "report":"c800846f-8478-4af8-85d1-a3f12fe4c18f",
+  "monitoring_host":"none",
+  "service": "SRMv2",
+  "hostname": "se01.afroditi.hellasgrid.gr",
+  "metric": "org.sam.SRM-Put",
+  "timestamp":"2015-01-01T00:00:00Z",
+  "status":"MISSING",
+  "summary":"missing",
+  "message":"missing"
+}


### PR DESCRIPTION
Based on given topology CE produces expected rows of hostname,service,metric. This set is compared with the received metric data and if combinations of hostname,service,metric are missing from the monitoring system they are filled in and added to the rest of the metric data. This enables CE to produce missing timelines for endpoints that are completely missing for long periods of time

- [x] Implement UnwindServiceMetric UDF to create all expected hostname,service,metric rows based on given topology
- [x] Implement FillMissing UDF to grab missing hostname,service,metric rows add fill in the rest of information (timestamp, missing status, null messages etc.)
- [x] Refactor compute-ar.pig 
 - [x] Create a set of expected (hostname,service,metric) data based on topology
 - [x] Subtract the set of expected (h,s,m) from the metric_data received. Use Cogroup to subtract
 - [x] The difference is the missing endpoints ...fill them with the rest of information
 - [x] Add them to the metric_data
- [x] Refactor compute-status.pig as well 
- [x] Add unittests 
