### PR TITLE
Fix in poller python script

### DIFF
--- a/bin/poller_ar.py
+++ b/bin/poller_ar.py
@@ -53,12 +53,11 @@ def run_recomputation(col, tenant, num_running, num_pending, threshold):
 
     pen_recalc = col.find_one({"status": "pending"})
     pen_recalc_id = str(pen_recalc["id"])
-    pen_recalc_r = str(pen_recalc["report"])
 
     # Status update allready implemented in recompute
     # Call recompute execution script
     recompute_script = script_path + "/recompute.py"
-    cmd_exec = [recompute_script, "-i", pen_recalc_id, "-t", tenant, "-j", pen_recalc_r]
+    cmd_exec = [recompute_script, "-i", pen_recalc_id, "-t", tenant]
     # Kickstart executor and continue own execution
     subprocess.Popen(cmd_exec)
 

--- a/bin/test_poller_ar.py
+++ b/bin/test_poller_ar.py
@@ -23,7 +23,7 @@ def test_run_recomputation(mock_popen):
 
     # Assert that the actual sys call is called with the correct arguments
     mock_popen.assert_called_with(
-        [script_path+"/recompute.py", '-i', '5559ed3306f6233c190bc851', '-t', 'FOO_tenant', '-j', 'critical'])
+        [script_path+"/recompute.py", '-i', '5559ed3306f6233c190bc851', '-t', 'FOO_tenant'])
 
 
 @mock.patch('poller_ar.subprocess.Popen')


### PR DESCRIPTION
# Description

The `poller_ar.py` calls the `recompute.py` wrapper with an additional argument (`-j`) that is not required and actually produces an exception. The latter wrapper picks up the name of the report directly from querying the mongo datastore. 