### PR TITLE
Change in mongo update call

### DIFF
--- a/bin/recompute.py
+++ b/bin/recompute.py
@@ -110,7 +110,7 @@ def update_status(collection, rec_id, status, timestamp, log):
     """
 
     # Update status and history
-    collection.update({'id': rec_id}, {'$set': {"status": status,"timestamp": timestamp} })
+    collection.update_one({'id': rec_id}, {'$set': {"status": status,"timestamp": timestamp.strftime("%Y-%m-%d %H:%M:%S")} })
 
 
 def recompute(recalculation_id=None, tenant=None):

--- a/bin/recompute_test.py
+++ b/bin/recompute_test.py
@@ -101,8 +101,8 @@ def test_update_status():
     recompute.update_status(mock_collection, "551bdd701c8a97e78635a911", "FOO", timestamp, log)
 
     query_id = {'id': '551bdd701c8a97e78635a911'}
-    query_update = {'$set': {'status': 'FOO','timestamp':timestamp}}
+    query_update = {'$set': {'status': 'FOO','timestamp':timestamp.strftime("%Y-%m-%d %H:%M:%S")}}
 
-    mock_collection.update.assert_called_with(query_id, query_update)
+    mock_collection.update_one.assert_called_with(query_id, query_update)
 
    


### PR DESCRIPTION
# Description

This PR introduces two changes:
 1. Removes a deprication warning emitted through python about the `update` function usage (see below)
 2. Inserts the timestamp of the state change in the format expected by the Web API

C/p the deprication warning is the following:
```
/usr/libexec/ar-compute/bin/recompute.py:113: DeprecationWarning: update is deprecated. Use replace_one, update_one or update_many instead.
  collection.update({'id': rec_id}, {'$set': {"status": status,"timestamp": timestamp} })
```