### PR TITLE
ARGO-388 Ingestion of sync data

### DIFF
--- a/doc/argo-compute-engine/ingestion_dataflow.md
+++ b/doc/argo-compute-engine/ingestion_dataflow.md
@@ -68,6 +68,10 @@ For each tenant Apache Flume should have a kafka source configured to the corres
 Flume dataflow store the metric data in the following hdfs destination:
 `/argo/{TENANT}/metric_data/date={date_timestamp}`
 
+Flume dataflow store the sync data in the following hdfs destination pattern:
+`/argo/{TENANT}/{type}/report={report_name}/date={date_timestamp}`
+where `{type}` is the type of sync data (weights,downtimes,endpoint_groups,group_groups,metric_profiles)
+
 Files are also accessible by hive if corresponding tables are created and set to those locations. Folder `./ingestion/hive/` includes scripts for creation of hive tables that query data on ingestion HDFS directories.
 
 Avro schema's used should be stored in an accessible hdfs destination such as '/argo/schemas/'

--- a/ingestion/flume/conf/flume-agent-metric-data.conf.template
+++ b/ingestion/flume/conf/flume-agent-metric-data.conf.template
@@ -29,7 +29,6 @@ flume1.sinks.hdfs-sink-1.hdfs.path = /user/root/argo/{tenant_name}/date=%{argo_d
 flume1.sinks.hdfs-sink-1.hdfs.rollCount=0
 flume1.sinks.hdfs-sink-1.hdfs.rollSize=0
 flume1.sinks.hdfs-sink-1.hdfs.rollInterval=1800
-#flume1.sinks.hdfs-sink-1.serializer = avro_event
 flume1.sinks.hdfs-sink-1.serializer = org.apache.flume.serialization.AvroEventSerializer$Builder
 
 

--- a/ingestion/flume/conf/flume-agent-sync-data.conf.template
+++ b/ingestion/flume/conf/flume-agent-sync-data.conf.template
@@ -1,0 +1,39 @@
+# Sources, channels, and sinks are defined per
+# agent name, in this case flume1.
+flume2.sources  = kafka-source-2
+flume2.channels = hdfs-channel-2
+flume2.sinks    = hdfs-sink-2
+
+# For each source, channel, and sink, set
+# standard properties.
+flume2.sources.kafka-source-2.type = org.apache.flume.source.kafka.KafkaSource
+flume2.sources.kafka-source-2.zookeeperConnect = {zookeeper_ip}
+flume2.sources.kafka-source-2.topic = {tenant_name}.sync_data
+flume2.sources.kafka-source-2.batchSize = 100
+flume2.sources.kafka-source-2.channels = hdfs-channel-2
+flume2.sources.kafka-source-2.interceptors = DecodeInterceptor
+flume2.sources.kafka-source-2.interceptors.DecodeInterceptor.type=argo.flume.interceptor.DecodeInterceptor$Builder
+flume2.sources.kafka-source-2.interceptors.DecodeInterceptor.schemaURL={path_to_hdfs_schemas_folder}
+
+
+flume2.channels.hdfs-channel-2.type   = memory
+flume2.sinks.hdfs-sink-2.channel = hdfs-channel-1
+flume2.sinks.hdfs-sink-2.type = hdfs
+flume2.sinks.hdfs-sink-2.hdfs.writeFormat = Text
+flume2.sinks.hdfs-sink-2.hdfs.fileType = DataStream
+flume2.sinks.hdfs-sink-2.hdfs.filePrefix = prefilter-%{argo_type}-%{argo_date}
+flume2.sinks.hdfs-sink-2.hdfs.fileSuffix = .avro
+flume2.sinks.hdfs-sink-2.hdfs.useLocalTimeStamp = true
+flume2.sinks.hdfs-sink-2.hdfs.proxyUser = root
+flume2.sinks.hdfs-sink-2.hdfs.path = /user/root/argo/{tenant_name}/report={report_name}/date=%{argo_date}
+flume2.sinks.hdfs-sink-2.hdfs.rollCount=0
+flume2.sinks.hdfs-sink-2.hdfs.rollSize=0
+flume1.sinks.hdfs-sink-2.hdfs.rollInterval=1800
+flume2.sinks.hdfs-sink-2.serializer = org.apache.flume.serialization.AvroEventSerializer$Builder
+
+
+# Other properties are specific to each type of
+# source, channel, or sink. In this case, we
+# specify the capacity of the memory channel.
+flume2.channels.hdfs-channel-2.capacity = 10000
+flume2.channels.hdfs-channel-2.transactionCapacity = 1000

--- a/ingestion/hive/scripts/hive_tbl_downtimes.sql
+++ b/ingestion/hive/scripts/hive_tbl_downtimes.sql
@@ -1,0 +1,20 @@
+CREATE TABLE downtimes
+  PARTITIONED BY (date STRING)
+  ROW FORMAT SERDE
+  'org.apache.hadoop.hive.serde2.avro.AvroSerDe'
+  STORED as INPUTFORMAT
+  'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat'
+  OUTPUTFORMAT
+  'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat'
+  LOCATION '/user/root/argo/${hiveconf:tenant}'
+  TBLPROPERTIES (
+     'avro.schema.literal'='{"namespace": "argo.avro",
+     "type": "record",
+     "name": "downtimes",
+     "fields": [
+        {"name": "hostname", "type": "string"},
+        {"name": "service", "type": "string"},
+        {"name": "start_time", "type": "string"},
+        {"name": "end_time", "type": "string"}
+     ]
+    }');

--- a/ingestion/hive/scripts/hive_tbl_endpoint_groups.sql
+++ b/ingestion/hive/scripts/hive_tbl_endpoint_groups.sql
@@ -1,0 +1,24 @@
+CREATE TABLE endpoint_groups
+  PARTITIONED BY (date STRING)
+  ROW FORMAT SERDE
+  'org.apache.hadoop.hive.serde2.avro.AvroSerDe'
+  STORED as INPUTFORMAT
+  'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat'
+  OUTPUTFORMAT
+  'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat'
+  LOCATION '/user/root/argo/${hiveconf:tenant}'
+  TBLPROPERTIES (
+     'avro.schema.literal'='{"namespace": "argo.avro",
+     "type": "record",
+     "name": "group_of_service_endpoints",
+     "fields": [
+            {"name": "type", "type": "string"},
+            {"name": "group", "type": "string"},
+            {"name": "service", "type": "string"},
+            {"name": "hostname", "type": "string"},
+            {"name": "tags", "type" : ["null", { "name" : "Tags",
+                                                 "type" : "map",
+                                                 "values" : ["int", "string"]
+                                              }]
+            }]
+    }');

--- a/ingestion/hive/scripts/hive_tbl_group_groups.sql
+++ b/ingestion/hive/scripts/hive_tbl_group_groups.sql
@@ -1,0 +1,23 @@
+CREATE TABLE group_groups
+  PARTITIONED BY (date STRING)
+  ROW FORMAT SERDE
+  'org.apache.hadoop.hive.serde2.avro.AvroSerDe'
+  STORED as INPUTFORMAT
+  'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat'
+  OUTPUTFORMAT
+  'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat'
+  LOCATION '/user/root/argo/${hiveconf:tenant}'
+  TBLPROPERTIES (
+     'avro.schema.literal'='{"namespace": "argo.avro",
+     "type": "record",
+     "name": "group_groups",
+     "fields": [
+        {"name": "type", "type": "string"},
+        {"name": "group", "type": "string"},
+        {"name": "subgroup", "type": "string"},
+        {"name": "tags", "type" : ["null", { "name" : "Tags",
+                                             "type" : "map",
+                                             "values" : ["int", "string"]
+                                          }]
+        }]
+    }');

--- a/ingestion/hive/scripts/hive_tbl_metric_data.sql
+++ b/ingestion/hive/scripts/hive_tbl_metric_data.sql
@@ -1,4 +1,4 @@
-CREATE TABLE user
+CREATE TABLE metric_data
   PARTITIONED BY (date STRING)
   ROW FORMAT SERDE
   'org.apache.hadoop.hive.serde2.avro.AvroSerDe'
@@ -6,7 +6,7 @@ CREATE TABLE user
   'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat'
   OUTPUTFORMAT
   'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat'
-  LOCATION '/user/root/${hiveconf:tenant}/EGI'
+  LOCATION '/user/root/argo/${hiveconf:tenant}'
   TBLPROPERTIES (
     'avro.schema.literal'='{"namespace": "argo.avro",
     "type": "record",

--- a/ingestion/hive/scripts/hive_tbl_metric_profiles.sql
+++ b/ingestion/hive/scripts/hive_tbl_metric_profiles.sql
@@ -1,0 +1,23 @@
+CREATE TABLE metric_profiles
+  PARTITIONED BY (date STRING)
+  ROW FORMAT SERDE
+  'org.apache.hadoop.hive.serde2.avro.AvroSerDe'
+  STORED as INPUTFORMAT
+  'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat'
+  OUTPUTFORMAT
+  'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat'
+  LOCATION '/user/root/argo/${hiveconf:tenant}'
+  TBLPROPERTIES (
+     'avro.schema.literal'='{"namespace": "argo.avro",
+     "type": "record",
+     "name": "metric_profiles",
+     "fields": [
+        {"name": "profile", "type": "string"},
+        {"name": "service", "type": "string"},
+        {"name": "metric", "type": "string"},
+        {"name": "tags", "type" : ["null", {"name" : "Tags",
+                                            "type" : "map",
+                                            "values" : ["int", "string"]
+                                           }]
+        }]
+    }');

--- a/ingestion/hive/scripts/hive_tbl_weights.sql
+++ b/ingestion/hive/scripts/hive_tbl_weights.sql
@@ -1,0 +1,19 @@
+CREATE TABLE weights
+  PARTITIONED BY (date STRING)
+  ROW FORMAT SERDE
+  'org.apache.hadoop.hive.serde2.avro.AvroSerDe'
+  STORED as INPUTFORMAT
+  'org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat'
+  OUTPUTFORMAT
+  'org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat'
+  LOCATION '/user/root/argo/${hiveconf:tenant}'
+  TBLPROPERTIES (
+     'avro.schema.literal'='{"namespace": "argo.avro",
+     "type": "record",
+     "name": "weight_sites",
+     "fields": [
+        {"name": "type", "type": "string"},
+        {"name": "site", "type": "string"},
+        {"name": "weight", "type": "string"}
+     ]
+    }');


### PR DESCRIPTION
## Goal

Prepare CE dataflow to be able to accept metric data through Ingestion (using the ingestion API)

## Implementation

Add Documentation, configuration and script regarding ingestion of sync data in the compute engine
- metric_profiles
- group_groups
- group_endpoints
- downtimes
- weights

To be merged after PR: https://github.com/ARGOeu/argo-compute-engine/pull/169