### PR TITLE
ARGO-455 Add consumers root path parameter. 

### DIFF
--- a/bin/upload_metric.py
+++ b/bin/upload_metric.py
@@ -21,6 +21,7 @@ def main(args=None):
     # Get sync exec and path
     arsync_exec = ArConfig.get('connectors', 'sync_exec')
     arsync_lib = ArConfig.get('connectors', 'sync_path')
+    consumers_root = ArConfig.get('consumers','consumers_root')
 
     # Get mode from config file
     ar_mode = ArConfig.get('default', 'mode')
@@ -67,7 +68,7 @@ def main(args=None):
     else:
         fn_mdata = 'argo-consumer_log_' + args.date + '.avro'
         fn_prefilter = "prefilter_" + date_under + ".avro"
-        local_mdata = os.path.join('/var/lib','argo-'+args.tenant.lower()+'-consumer',fn_mdata)
+        local_mdata = os.path.join(consumers_root,'argo-'+args.tenant.lower()+'-consumer',fn_mdata)
         local_prefilter = os.path.join(arsync_lib, args.tenant, fn_prefilter)
         cmd_copy = ['cp', local_mdata , local_prefilter ]
         run_cmd(cmd_copy,log)

--- a/bin/utils.py
+++ b/bin/utils.py
@@ -20,6 +20,8 @@ class ArgoConfiguration(object):
     # connector parameters
     sync_exec = None
     sync_path = None
+    # consumers parmeters
+    consumers_root = None
     # ce run mode
     mode = None
     # sampling
@@ -71,6 +73,7 @@ class ArgoConfiguration(object):
         # Grab connector sync path
         self.sync_exec = ar_config.get('connectors', 'sync_exec')
         self.sync_path = ar_config.get('connectors', 'sync_path')
+        self.consumers_root = ar_config.get('consumers','consumers_root')
 
         # Grab run mode
         self.mode = ar_config.get('default', 'mode')

--- a/bin/utils_test.py
+++ b/bin/utils_test.py
@@ -4,7 +4,7 @@ from utils import *
 
 TEST_CONF_CONTENTS = r"""
 [default]
-mongo_host=127.0.0.1 
+mongo_host=127.0.0.1
 mongo_port=27017
 mode=local
 
@@ -13,7 +13,7 @@ sync_clean=true
 
 recomp_threshold=1
 
-[logging]    
+[logging]
 log_mode=file
 log_file=/var/log/ar-compute.log
 log_level=debug
@@ -22,6 +22,9 @@ log_level=debug
 tenants=TenantA,TenantB
 TenantA_jobs=JobA,JobB
 TenantB_jobs=JobC,JobD
+
+[consumers]
+consumers_root=/var/lib
 
 [connectors]
 sync_exec=/usr/libexec/argo-egi-connectors
@@ -140,6 +143,7 @@ def test_load_configuration(tmpdir):
 
     assert cfg.sync_exec == "/usr/libexec/argo-egi-connectors"
     assert cfg.sync_path == "/var/lib/argo-connectors"
+    assert cfg.consumers_root == "/var/lib"
 
     assert cfg.mode == "local"
 

--- a/conf/ar-compute-engine.conf.template
+++ b/conf/ar-compute-engine.conf.template
@@ -49,6 +49,9 @@ log_level=DEBUG
 # SYSLOG appender in the following line
 hadoop_log_root=INFO,console
 
+[consumers]
+consumers_root=/var/lib
+
 [connectors]
 
 sync_conf=/etc/argo-egi-connectors/


### PR DESCRIPTION
## Issue
In tenants that doesn't use prefiltering retrieval of consumer data is hard coded to `/var/lib/consumer-...`

## Implementations
- [x] Add consumers root path parameter. 
- [x] Update upload_metric script accordingly. 
- [x] Update unit tests