### PR TITLE
ARGO-581 Use Update when storing results in mongo

### DIFF
--- a/bin/job_ar.py
+++ b/bin/job_ar.py
@@ -115,9 +115,6 @@ def main(args=None):
     cmd_pig.append('-f')
     cmd_pig.append(pig_script_path + 'compute-ar.pig')
 
-    # Command to clean a/r data from mongo
-    cmd_clean_mongo_ar = [os.path.join(
-        stdl_exec, "mongo_clean_ar.py"), '-d', args.date, '-r', json_cfg["id"], '-t', args.tenant]
 
     # Command to upload sync data to hdfs
     cmd_upload_sync = [os.path.join(
@@ -130,9 +127,7 @@ def main(args=None):
     log.info("Uploading sync data to hdfs...")
     run_cmd(cmd_upload_sync, log)
 
-    # Clean data from mongo
-    log.info("Cleaning data from mongodb...")
-    run_cmd(cmd_clean_mongo_ar, log)
+
 
     # Call pig
     log.info("Submitting pig compute a/r job:%s for tenant:%s and date:%s ...",

--- a/bin/job_status_detail.py
+++ b/bin/job_status_detail.py
@@ -108,9 +108,6 @@ def main(args=None):
     cmd_pig.append('-f')
     cmd_pig.append(pig_script_path + 'compute-status.pig')
 
-    # Command to clean a/r data from mongo
-    cmd_clean_mongo_status = [
-        os.path.join(stdl_exec, "mongo_clean_status.py"), '-d', args.date, '-t', args.tenant, '-r', json_cfg['id']]
 
     # Command to upload sync data to hdfs
     cmd_upload_sync = [os.path.join(
@@ -123,9 +120,6 @@ def main(args=None):
     log.info("Uploading sync data to hdfs...")
     run_cmd(cmd_upload_sync, log)
 
-    # Clean data from mongo
-    log.info("Cleaning data from mongodb")
-    run_cmd(cmd_clean_mongo_status, log)
 
     # Call pig
     log.info("Submitting pig compute status detail job...")

--- a/bin/mongo_clean_ar.py
+++ b/bin/mongo_clean_ar.py
@@ -55,7 +55,7 @@ def main(args=None):
             num_of_rows = col.find({"date": date_int}).count()
             log.info("Found %s entries for date %s", num_of_rows, args.date)
 
-        if num_of_rows > 0:
+        if num_of_rows > 0: #never happens
 
             if args.report:
                 log.info(

--- a/status-computation/pig/compute-ar.pig
+++ b/status-computation/pig/compute-ar.pig
@@ -104,5 +104,18 @@ endpoint_groups_ar = FOREACH endpoint_groups GENERATE FLATTEN(f_EndpointGroupAR(
 service_data = FOREACH service_ar GENERATE FLATTEN(f_ServiceDATA(service,groupname,availability,reliability,up_f,unknown_f,down_f)) AS (report,date,name,supergroup,availability,reliability,up,down,unknown);
 endpoint_groups_data = FOREACH endpoint_groups_ar GENERATE FLATTEN(f_egroupDATA(groupname,availability,reliability,up_f,unknown_f,down_f)) AS (report,date,name,supergroup,weight,availability,reliability,up,down,unknown);
 
-STORE service_data INTO '$mongo_service' USING com.mongodb.hadoop.pig.MongoInsertStorage();
-STORE endpoint_groups_data INTO '$mongo_egroup' USING com.mongodb.hadoop.pig.MongoInsertStorage();
+
+STORE service_data INTO '$mongo_service'
+	 USING com.mongodb.hadoop.pig.MongoUpdateStorage(
+		  '{report:"\$report", date:"\$date", name:"\$name", supergroup:"\$supergroup" }',
+			'{report:"\$report", date:"\$date", name:"\$name", supergroup:"\$supergroup", availability:"\$availability", reliability:"\$reliability", up:"\$up", down:"\$down", unkown:"\$unknown" }',
+			'report: chararray,date: int,name: chararray,supergroup: chararray,availability: double,reliability: double,up: double,down: double,unknown: double',
+			'{upsert:true}'
+		 );
+STORE endpoint_groups_data INTO '$mongo_egroup'
+		USING com.mongodb.hadoop.pig.MongoUpdateStorage(
+		 '{report:"\$report", date:"\$date", name:"\$name", supergroup:"\$supergroup" }',
+		 '{report:"\$report", date:"\$date", name:"\$name", supergroup:"\$supergroup", weight:"\$weight", availability:"\$availability", reliability:"\$reliability", up:"\$up", down:"\$down", unkown:"\$unknown" }',
+		 'report: chararray,date: int,name: chararray,supergroup: chararray,weight: int,availability: double,reliability: double,up: double,down: double,unknown: double',
+		 '{upsert:true}'
+		);

--- a/status-computation/pig/compute-status.pig
+++ b/status-computation/pig/compute-status.pig
@@ -97,7 +97,35 @@ endpoint_data = FOREACH endpoint_aggr GENERATE $0 as report, $1 as date_integer,
 service_data = FOREACH service_aggr GENERATE $0 as report, $1 as date_integer, $2 as endpoint_group, $3 as service, FLATTEN($4) as (timestamp,status);
 endpoint_group_data = FOREACH endpoint_group_aggr GENERATE $0 as report, $1 as date_integer, $2 as endpoint_group, FLATTEN($3) as (timestamp,status);
 
-STORE status_unwrap INTO '$mongo_status_metrics' USING com.mongodb.hadoop.pig.MongoInsertStorage();
-STORE endpoint_data INTO '$mongo_status_endpoints' USING com.mongodb.hadoop.pig.MongoInsertStorage();
-STORE service_data INTO '$mongo_status_services' USING com.mongodb.hadoop.pig.MongoInsertStorage();
-STORE endpoint_group_data INTO '$mongo_status_endpoint_groups' USING com.mongodb.hadoop.pig.MongoInsertStorage();
+
+STORE status_unwrap INTO '$mongo_status_metrics'
+	 USING com.mongodb.hadoop.pig.MongoUpdateStorage(
+		  '{report:"\$report", date_integer:"\$date_integer", service:"\$service", host:"\$host", metric:"\$metric", timestamp:"\$timestamp" }',
+			'{report:"\$report", date_integer:"\$date_integer", service:"\$service", host:"\$host", metric:"\$metric", timestamp:"\$timestamp", status:"\$status", summary:"\$summary", message:"\$message", previous_state:"\$previous_state", previous_timestamp:"\$previous_timestamp", time_integer:"\$time_integer" }',
+			'report: chararray,endpoint_group: chararray,service: chararray,host: chararray,metric: chararray,timestamp: chararray,status: chararray,summary: chararray,message: chararray,previous_state: chararray,previous_timestamp: chararray,date_integer: int,time_integer: int',
+			'{upsert:true}'
+		 );
+
+STORE endpoint_data INTO '$mongo_status_endpoints'
+	 USING com.mongodb.hadoop.pig.MongoUpdateStorage(
+		  '{report:"\$report", date_integer:"\$date_integer", endpoint_group:"\$endpoint_group", service:"\$service", host:"\$host", timestamp:"\$timestamp" }',
+			'{report:"\$report", date_integer:"\$date_integer", endpoint_group:"\$endpoint_group", service:"\$service", host:"\$host", timestamp:"\$timestamp", status:"\$status" }',
+			'report: chararray,date_integer: int,endpoint_group: chararray,service: chararray,host: chararray,timestamp: chararray,status: chararray',
+			'{upsert:true}'
+		 );
+
+STORE service_data INTO '$mongo_status_services'
+ 	 USING com.mongodb.hadoop.pig.MongoUpdateStorage(
+ 		  '{report:"\$report", date_integer:"\$date_integer", endpoint_group:"\$endpoint_group", service:"\$service", timestamp:"\$timestamp" }',
+ 			'{report:"\$report", date_integer:"\$date_integer", endpoint_group:"\$endpoint_group", service:"\$service", timestamp:"\$timestamp", status:"\$status" }',
+ 			'report: chararray,date_integer: int,endpoint_group: chararray,service: chararray,timestamp: chararray,status: chararray',
+ 			'{upsert:true}'
+ 		 );
+
+STORE endpoint_group_data INTO '$mongo_status_endpoint_groups'
+	 USING com.mongodb.hadoop.pig.MongoUpdateStorage(
+		  '{report:"\$report", date_integer:"\$date_integer", endpoint_group:"\$endpoint_group", timestamp:"\$timestamp" }',
+			'{report:"\$report", date_integer:"\$date_integer", endpoint_group:"\$endpoint_group", timestamp:"\$timestamp", status:"\$status" }',
+			'report: chararray,date_integer: int,endpoint_group: chararray,timestamp: chararray,status: chararray',
+			'{upsert:true}'
+		 );


### PR DESCRIPTION
### Issue
Mongodb result set (for a given collection, report and date) is cleared before hadoop computation begins. Until computation finished old results are thus missing from the datastore

### Implementation
- [x] Use MongoUpdate in pig scripts when storing results to the database
 - [x] refactor compute-ar.pig to use MongoUpdate for a/r results
 - [x] refactor compute-status.pig to user MongoUpdate for status results
- [x] Stop mongo_clean_*.py scripts from cleaning datastore before computations
 - [x] Refactor job_ar.py to not use mongo_clean_ar.py
 - [x] Refactor job_status_detail.py to not user mongo_clean_status.py