### PR TITLE
ARGO-611 Add ommited endpoint_group field in update status_metrics

### DIFF
--- a/status-computation/pig/compute-status.pig
+++ b/status-computation/pig/compute-status.pig
@@ -101,7 +101,7 @@ endpoint_group_data = FOREACH endpoint_group_aggr GENERATE $0 as report, $1 as d
 STORE status_unwrap INTO '$mongo_status_metrics'
 	 USING com.mongodb.hadoop.pig.MongoUpdateStorage(
 		  '{report:"\$report", date_integer:"\$date_integer", service:"\$service", host:"\$host", metric:"\$metric", timestamp:"\$timestamp" }',
-			'{report:"\$report", date_integer:"\$date_integer", service:"\$service", host:"\$host", metric:"\$metric", timestamp:"\$timestamp", status:"\$status", summary:"\$summary", message:"\$message", previous_state:"\$previous_state", previous_timestamp:"\$previous_timestamp", time_integer:"\$time_integer" }',
+			'{report:"\$report", date_integer:"\$date_integer", endpoint_group:"\$endpoint_group", service:"\$service", host:"\$host", metric:"\$metric", timestamp:"\$timestamp", status:"\$status", summary:"\$summary", message:"\$message", previous_state:"\$previous_state", previous_timestamp:"\$previous_timestamp", time_integer:"\$time_integer" }',
 			'report: chararray,endpoint_group: chararray,service: chararray,host: chararray,metric: chararray,timestamp: chararray,status: chararray,summary: chararray,message: chararray,previous_state: chararray,previous_timestamp: chararray,date_integer: int,time_integer: int',
 			'{upsert:true}'
 		 );


### PR DESCRIPTION
### Issue
`endpoint_group` field was ommited from the update status_metric procedure. The field was used in query for displaying status metric results

### Fix
 - Add endpoint_group field in update statement in compute_status pig script