### PR TITLE
ARGO-599 Add Hbase destination to stream pipeline

### DIFF
--- a/streaming/stream_hbase/metric_data.avsc
+++ b/streaming/stream_hbase/metric_data.avsc
@@ -1,0 +1,18 @@
+{"namespace": "argo.avro",
+ "type": "record",
+ "name": "metric_data",
+ "fields": [
+        {"name": "timestamp", "type": "string"},
+        {"name": "service", "type": "string"},
+        {"name": "hostname", "type": "string"},
+        {"name": "metric", "type": "string"},
+        {"name": "status", "type": "string"},
+        {"name": "monitoring_host", "type": ["null", "string"]},
+        {"name": "summary", "type": ["null", "string"]},
+        {"name": "message", "type": ["null", "string"]},
+        {"name": "tags", "type" : ["null", {"name" : "Tags",
+                                             "type" : "map",
+                                             "values" : ["null", "string"]
+                                           }]
+        }]
+}

--- a/streaming/stream_hbase/pom.xml
+++ b/streaming/stream_hbase/pom.xml
@@ -1,23 +1,23 @@
-<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
-	license agreements. See the NOTICE file distributed with this work for additional
-	information regarding copyright ownership. The ASF licenses this file to
-	you under the Apache License, Version 2.0 (the "License"); you may not use
-	this file except in compliance with the License. You may obtain a copy of
-	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
-	by applicable law or agreed to in writing, software distributed under the
-	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
-	OF ANY KIND, either express or implied. See the License for the specific
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
 	language governing permissions and limitations under the License. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>argo-streaming-hdfs</groupId>
-	<artifactId>argo-streaming-hdfs</artifactId>
+	<groupId>argo-streaming-hbase</groupId>
+	<artifactId>argo-streaming-hbase</artifactId>
 	<version>0.1</version>
 	<packaging>jar</packaging>
 
-	<name>ARGO Streaming job to HDFS</name>
+	<name>ARGO Streaming job to hbase</name>
 
 
 	<properties>
@@ -26,6 +26,10 @@
 	</properties>
 
 	<repositories>
+		<repository>
+			<id>cloudera</id>
+			<url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+		</repository>
 		<repository>
 			<id>apache.snapshots</id>
 			<name>Apache Development Snapshot Repository</name>
@@ -39,17 +43,16 @@
 		</repository>
 	</repositories>
 
-
-	<!-- Execute "mvn clean package -Pbuild-jar" to build a jar file out of
-		this project! How to use the Flink Quickstart pom: a) Adding new dependencies:
-		You can add dependencies to the list below. Please check if the maven-shade-plugin
-		below is filtering out your dependency and remove the exclude from there.
-		b) Build a jar for running on the cluster: There are two options for creating
-		a jar from this project b.1) "mvn clean package" -> this will create a fat
-		jar which contains all dependencies necessary for running the jar created
-		by this pom in a cluster. The "maven-shade-plugin" excludes everything that
-		is provided on a running Flink cluster. b.2) "mvn clean package -Pbuild-jar"
-		-> This will also create a fat-jar, but with much nicer dependency exclusion
+	<!-- Execute "mvn clean package -Pbuild-jar" to build a jar file out of 
+		this project! How to use the Flink Quickstart pom: a) Adding new dependencies: 
+		You can add dependencies to the list below. Please check if the maven-shade-plugin 
+		below is filtering out your dependency and remove the exclude from there. 
+		b) Build a jar for running on the cluster: There are two options for creating 
+		a jar from this project b.1) "mvn clean package" -> this will create a fat 
+		jar which contains all dependencies necessary for running the jar created 
+		by this pom in a cluster. The "maven-shade-plugin" excludes everything that 
+		is provided on a running Flink cluster. b.2) "mvn clean package -Pbuild-jar" 
+		-> This will also create a fat-jar, but with much nicer dependency exclusion 
 		handling. This approach is preferred and leads to much cleaner jar files. -->
 
 	<dependencies>
@@ -81,7 +84,7 @@
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-kafka-0.9_2.10</artifactId>
-				<version>${flink.version}</version>
+			<version>${flink.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>
@@ -93,7 +96,11 @@
 			<artifactId>gson</artifactId>
 			<version>2.7</version>
 		</dependency>
-				<!-- https://mvnrepository.com/artifact/org.apache.hbase/hbase-client -->
+		<dependency>
+			<groupId>org.apache.hbase</groupId>
+			<artifactId>hbase-client</artifactId>
+			<version>1.2.0-cdh5.7.4</version>
+		</dependency>
 
 
 	</dependencies>
@@ -126,7 +133,7 @@
 				</dependency>
 				<dependency>
 					<groupId>org.apache.flink</groupId>
-					<artifactId>flink-connector-kafka-0.8_2.10</artifactId>
+					<artifactId>flink-connector-kafka-0.9_2.10</artifactId>
 					<version>${flink.version}</version>
 					<scope>provided</scope>
 				</dependency>
@@ -173,10 +180,9 @@
 
 	<build>
 		<plugins>
-
-			<!-- We use the maven-shade plugin to create a fat jar that contains all
-				dependencies except flink and it's transitive dependencies. The resulting
-				fat-jar can be executed on a cluster. Change the value of Program-Class if
+			<!-- We use the maven-shade plugin to create a fat jar that contains all 
+				dependencies except flink and it's transitive dependencies. The resulting 
+				fat-jar can be executed on a cluster. Change the value of Program-Class if 
 				your program entry point changes. -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -192,8 +198,7 @@
 						<configuration>
 							<artifactSet>
 								<excludes>
-
-									<!-- This list contains all dependencies of flink-dist Everything
+									<!-- This list contains all dependencies of flink-dist Everything 
 										else will be packaged into the fat-jar -->
 									<exclude>org.apache.flink:flink-annotations</exclude>
 									<exclude>org.apache.flink:flink-shaded-hadoop1</exclude>
@@ -210,9 +215,8 @@
 									<exclude>org.apache.flink:flink-examples-streaming_2.10</exclude>
 									<exclude>org.apache.flink:flink-streaming-java_2.10</exclude>
 
-
-									<!-- Also exclude very big transitive dependencies of Flink WARNING:
-										You have to remove these excludes if your code relies on other versions of
+									<!-- Also exclude very big transitive dependencies of Flink WARNING: 
+										You have to remove these excludes if your code relies on other versions of 
 										these dependencies. -->
 									<exclude>org.scala-lang:scala-library</exclude>
 									<exclude>org.scala-lang:scala-compiler</exclude>
@@ -274,8 +278,7 @@
 									</excludes>
 								</filter>
 								<filter>
-
-									<!-- Do not copy the signatures in the META-INF folder. Otherwise,
+									<!-- Do not copy the signatures in the META-INF folder. Otherwise, 
 										this might cause SecurityExceptions when using the JAR. -->
 									<artifact>*:*</artifact>
 									<excludes>
@@ -289,7 +292,7 @@
 								<!-- add Main-Class to manifest file -->
 								<transformer
 									implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-									<mainClass>argoflink.ArgoStreamHDFS</mainClass>
+									<mainClass>wikiedits.Job</mainClass>
 								</transformer>
 							</transformers>
 							<createDependencyReducedPom>false</createDependencyReducedPom>
@@ -310,32 +313,22 @@
 		</plugins>
 
 
-
-		<!-- If you want to use Java 8 Lambda Expressions uncomment the following
+		<!-- If you want to use Java 8 Lambda Expressions uncomment the following 
 			lines -->
-		<!-- <pluginManagement> <plugins> <plugin> <artifactId>maven-compiler-plugin</artifactId>
-			<configuration> <source>1.8</source> <target>1.8</target> <compilerId>jdt</compilerId>
-			</configuration> <dependencies> <dependency> <groupId>org.eclipse.tycho</groupId>
-			<artifactId>tycho-compiler-jdt</artifactId> <version>0.21.0</version> </dependency>
-			</dependencies> </plugin> <plugin> <groupId>org.eclipse.m2e</groupId> <artifactId>lifecycle-mapping</artifactId>
-			<version>1.0.0</version> <configuration> <lifecycleMappingMetadata> <pluginExecutions>
-			<pluginExecution> <pluginExecutionFilter> <groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-assembly-plugin</artifactId> <versionRange>[2.4,)</versionRange>
-			<goals> <goal>single</goal> </goals> </pluginExecutionFilter> <action> <ignore/>
-			</action> </pluginExecution> <pluginExecution> <pluginExecutionFilter> <groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-compiler-plugin</artifactId> <versionRange>[3.1,)</versionRange>
-			<goals> <goal>testCompile</goal> <goal>compile</goal> </goals> </pluginExecutionFilter>
-			<action> <ignore/> </action> </pluginExecution> </pluginExecutions> </lifecycleMappingMetadata>
+		<!-- <pluginManagement> <plugins> <plugin> <artifactId>maven-compiler-plugin</artifactId> 
+			<configuration> <source>1.8</source> <target>1.8</target> <compilerId>jdt</compilerId> 
+			</configuration> <dependencies> <dependency> <groupId>org.eclipse.tycho</groupId> 
+			<artifactId>tycho-compiler-jdt</artifactId> <version>0.21.0</version> </dependency> 
+			</dependencies> </plugin> <plugin> <groupId>org.eclipse.m2e</groupId> <artifactId>lifecycle-mapping</artifactId> 
+			<version>1.0.0</version> <configuration> <lifecycleMappingMetadata> <pluginExecutions> 
+			<pluginExecution> <pluginExecutionFilter> <groupId>org.apache.maven.plugins</groupId> 
+			<artifactId>maven-assembly-plugin</artifactId> <versionRange>[2.4,)</versionRange> 
+			<goals> <goal>single</goal> </goals> </pluginExecutionFilter> <action> <ignore/> 
+			</action> </pluginExecution> <pluginExecution> <pluginExecutionFilter> <groupId>org.apache.maven.plugins</groupId> 
+			<artifactId>maven-compiler-plugin</artifactId> <versionRange>[3.1,)</versionRange> 
+			<goals> <goal>testCompile</goal> <goal>compile</goal> </goals> </pluginExecutionFilter> 
+			<action> <ignore/> </action> </pluginExecution> </pluginExecutions> </lifecycleMappingMetadata> 
 			</configuration> </plugin> </plugins> </pluginManagement> -->
 
 	</build>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.apache.flink</groupId>
-				<artifactId>flink-connector-kafka-0.9_2.10</artifactId>
-				<version>${flink.version}</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 </project>

--- a/streaming/stream_hbase/src/main/java/argoflink/ArgoStreamHbase.java
+++ b/streaming/stream_hbase/src/main/java/argoflink/ArgoStreamHbase.java
@@ -1,0 +1,261 @@
+package argoflink;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.util.Arrays;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.commons.codec.binary.Base64;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.io.OutputFormat;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumer09;
+import org.apache.flink.streaming.util.serialization.SimpleStringSchema;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+//Flink Job : Stream metric data from Kafka Broker to Hbase
+//job required cli parameters
+//--zookeeper.connect {comma separated list of Zookeeper servers}
+//--bootstrap.servers {comma separated list of Kafka servers}
+//--group.id {consumer group}
+//--schema {avro schema file to be used}
+//--topic {kafka topic to connect to}
+//--hbase-master      : hbase endpoint
+//--hbase-master-port : hbase master port
+//--hbase-zk-quorum   : comma separated list of hbase zookeeper servers
+//--hbase-zk-port     : port used by hbase zookeeper servers
+//--hbase-namespace   : table namespace used (usually tenant name)
+//--hbase-table       : table name (usually metric_data)
+public class ArgoStreamHbase {
+	// setup logger
+	static Logger LOG = LoggerFactory.getLogger(ArgoStreamHbase.class);
+	// avro schema to be used
+	static Schema avroSchema = null;
+	// avro reader
+	static DatumReader<GenericRecord> avroReader = null;
+
+	// Load an avro schema from a filename
+	public static void loadSchema(String filename) throws IOException {
+		avroSchema = new Schema.Parser().parse(new File(filename));
+		avroReader = new SpecificDatumReader<GenericRecord>(avroSchema);
+
+	}
+
+	// Decode
+	public static GenericRecord avroDec(byte[] payload) {
+		// setup decoder using the payload
+		Decoder decoder = DecoderFactory.get().binaryDecoder(payload, null);
+		GenericRecord payload2;
+		try {
+			// try to decode
+			payload2 = avroReader.read(null, decoder);
+		} catch (IOException e) {
+			// if not avro log and return null as result
+			LOG.warn("Payload not in avro format:{}", new String(payload));
+			return null;
+		}
+		return payload2;
+	}
+
+	public static void main(String[] args) throws Exception {
+
+		// Create flink execution enviroment
+		StreamExecutionEnvironment see = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		// Initialize cli parameter tool
+		final ParameterTool parameterTool = ParameterTool.fromArgs(args);
+
+		// Source: Kafka consumer - Listen to a (cli defined) topic name
+		DataStream<String> messageStream = see.addSource(new FlinkKafkaConsumer09<String>(
+				parameterTool.getRequired("topic"), new SimpleStringSchema(), parameterTool.getProperties()));
+
+		// Initialize Output : Hbase Output Format
+		HBaseOutputFormat hbf = new HBaseOutputFormat();
+		hbf.setMaster(parameterTool.getRequired("hbase-master"));
+		hbf.setMasterPort(parameterTool.getRequired("hbase-master-port"));
+		hbf.setZkQuorum(parameterTool.getRequired("hbase-zk-quorum"));
+		hbf.setZkPort(parameterTool.getRequired("hbase-zk-port"));
+		hbf.setNamespace(parameterTool.getRequired("hbase-namespace"));
+		hbf.setTableName(parameterTool.getRequired("hbase-table"));
+
+		// Intermediate Transformation
+		// Map function: kafka msg in json -> extract data field -> base64
+		// decode -> avro decode -> pure payload string
+		messageStream.rebalance().map(new MapFunction<String, String>() {
+
+			private static final long serialVersionUID = -2363832803416068415L;
+
+			@Override
+			public String map(String value) throws IOException {
+				JsonParser jsonParser = new JsonParser();
+				// parse the json root object
+				JsonElement jRoot = jsonParser.parse(value);
+				// parse the json field "data" and read it as string
+				// this is the base64 string payload
+				String data = jRoot.getAsJsonObject().get("data").getAsString();
+				// Decode from base64
+				byte[] decoded64 = Base64.decodeBase64(data.getBytes("UTF-8"));
+				// Decode from avro
+				Schema avroSchema = new Schema.Parser().parse(new File(parameterTool.getRequired("avro-schema")));
+				DatumReader<GenericRecord> avroReader = new SpecificDatumReader<GenericRecord>(avroSchema);
+				Decoder decoder = DecoderFactory.get().binaryDecoder(decoded64, null);
+				GenericRecord payload2;
+				payload2 = avroReader.read(null, decoder);
+				// If not avro return the string
+				if (payload2 != null) {
+					return payload2.toString();
+				} else {
+					return Arrays.toString(decoded64);
+				}
+			}
+			// Add rolling sink
+		}).writeUsingOutputFormat(hbf);
+
+		// Execute flink dataflow
+		see.execute();
+	}
+
+	// Hbase output format
+	private static class HBaseOutputFormat implements OutputFormat<String> {
+
+		private String master = null;
+		private String masterPort = null;
+		private String zkQuorum = null;
+		private String zkPort = null;
+		private String namespace = null;
+		private String tname = null;
+		private Connection connection = null;
+		private Table ht = null;
+		private int num = 1;
+
+		private static final long serialVersionUID = 1L;
+
+		// Setters
+		public void setMasterPort(String masterPort) {
+			this.masterPort = masterPort;
+		}
+
+		public void setMaster(String master) {
+			this.master = master;
+		}
+
+		public void setZkQuorum(String zkQuorum) {
+			this.zkQuorum = zkQuorum;
+		}
+
+		public void setZkPort(String zkPort) {
+			this.zkPort = zkPort;
+		}
+
+		public void setNamespace(String namespace) {
+			this.namespace = namespace;
+		}
+
+		public void setTableName(String tname) {
+			this.tname = tname;
+		}
+
+		@Override
+		public void configure(Configuration parameters) {
+
+		}
+
+		@Override
+		public void open(int taskNumber, int numTasks) throws IOException {
+			// Create hadoop based configuration for hclient to use
+			org.apache.hadoop.conf.Configuration config = HBaseConfiguration.create();
+			// Modify configuration to job needs
+			config.setInt("timeout", 120000);
+			if (masterPort != null && !masterPort.isEmpty()) {
+				config.set("hbase.master", master + ":" + masterPort);
+			} else {
+				config.set("hbase.master", master + ":60000");
+			}
+
+			config.set("hbase.zookeeper.quorum", zkQuorum);
+			config.set("hbase.zookeeper.property.clientPort", (zkPort));
+			// Create the connection
+			connection = ConnectionFactory.createConnection(config);
+			if (namespace != null) {
+				ht = connection.getTable(TableName.valueOf(namespace + ":" + tname));
+			} else {
+				ht = connection.getTable(TableName.valueOf(tname));
+			}
+
+		}
+
+		private String extractJson(String field, JsonObject root) {
+			JsonElement el = root.get(field);
+			if (el != null && !(el.isJsonNull())) {
+
+				return el.getAsString();
+
+			}
+			return "";
+		}
+
+		@Override
+		public void writeRecord(String record) throws IOException {
+
+			JsonParser jsonParser = new JsonParser();
+			// parse the json root object
+			JsonObject jRoot = jsonParser.parse(record).getAsJsonObject();
+			// Get fields
+			String ts = extractJson("timestamp", jRoot);
+			String host = extractJson("hostname", jRoot);
+			String service = extractJson("service", jRoot);
+			String metric = extractJson("metric", jRoot);
+			String mHost = extractJson("monitoring_host", jRoot);
+			String status = extractJson("status", jRoot);
+			String summary = extractJson("summary", jRoot);
+			String msg = extractJson("message", jRoot);
+
+			// Compile key
+			String key = host + "|" + service + "|" + metric + "|" + mHost + "|" + ts;
+			// Prepare columns
+			Put put = new Put(Bytes.toBytes(key));
+			put.addColumn(Bytes.toBytes("data"), Bytes.toBytes("timestamp"), Bytes.toBytes(ts));
+			put.addColumn(Bytes.toBytes("data"), Bytes.toBytes("host"), Bytes.toBytes(host));
+			put.addColumn(Bytes.toBytes("data"), Bytes.toBytes("service"), Bytes.toBytes(service));
+			put.addColumn(Bytes.toBytes("data"), Bytes.toBytes("metric"), Bytes.toBytes(metric));
+			put.addColumn(Bytes.toBytes("data"), Bytes.toBytes("monitoring_host"), Bytes.toBytes(mHost));
+			put.addColumn(Bytes.toBytes("data"), Bytes.toBytes("status"), Bytes.toBytes(status));
+			put.addColumn(Bytes.toBytes("data"), Bytes.toBytes("summary"), Bytes.toBytes(summary));
+			put.addColumn(Bytes.toBytes("data"), Bytes.toBytes("msg"), Bytes.toBytes(msg));
+
+			// Insert row in hbase
+			ht.put(put);
+
+		}
+
+		@Override
+		public void close() throws IOException {
+			ht.close();
+			connection.close();
+		}
+
+	}
+}

--- a/streaming/stream_hbase/src/main/resources/log4j.properties
+++ b/streaming/stream_hbase/src/main/resources/log4j.properties
@@ -1,0 +1,23 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=INFO, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n

--- a/streaming/stream_hbase/src/main/resources/schemas/metric_data.avsc
+++ b/streaming/stream_hbase/src/main/resources/schemas/metric_data.avsc
@@ -1,0 +1,18 @@
+{"namespace": "argo.avro",
+ "type": "record",
+ "name": "metric_data",
+ "fields": [
+        {"name": "timestamp", "type": "string"},
+        {"name": "service", "type": "string"},
+        {"name": "hostname", "type": "string"},
+        {"name": "metric", "type": "string"},
+        {"name": "status", "type": "string"},
+        {"name": "monitoring_host", "type": ["null", "string"]},
+        {"name": "summary", "type": ["null", "string"]},
+        {"name": "message", "type": ["null", "string"]},
+        {"name": "tags", "type" : ["null", {"name" : "Tags",
+                                             "type" : "map",
+                                             "values" : ["null", "string"]
+                                           }]
+        }]
+}


### PR DESCRIPTION
*To be merged after: https://github.com/ARGOeu/argo-compute-engine/pull/178

# Goal 
Add Hbase as destination in argo streaming pipeline

# Implementation
- Add two job subfolders in `/streaming` : `stream_hdfs`, `stream_hbase`
- Add HbaseOutputFormat impementation
- User WriteTo HbaseOutputFormat as a destination in stream pipeline

